### PR TITLE
docs: clarify repo purpose and install flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,61 @@
+# agent-skills
+
+RDL's repository for authoring, documenting, and validating Agent Skills.
+
+## Overview
+
+The core unit in this repo is a **self-contained skill**. Each skill lives in its
+own directory under `skills/` and carries the instructions, metadata, and any
+supporting files it needs.
+
+These skills follow the [Agent Skills Specification](https://agentskills.io/specification).
+The repo-specific format and structure used here are outlined in
+[`docs/specification.mdx`](docs/specification.mdx).
+
+At minimum, a skill contains a `SKILL.md` file:
+
+```text
+skills/<skill-name>/
+|- SKILL.md
+|- scripts/      # optional
+|- references/   # optional
+|- assets/       # optional
+```
+
+That packaging model is intentional: skills should be portable, reviewable, and
+easy to validate without depending on repo-wide runtime glue.
+
+## Repo Scope
+
+This repo is for:
+
+- authoring skills in `skills/`
+- documenting the format and authoring guidance in `docs/`
+- validating skills with the reference tooling in `src/skills/ref/`
+- testing that validation and prompt-generation behavior in `tests/`
+
+This repo is **not** the packaging or installation layer.
+
+RDL uses [`nq-rdl/agent-extensions`](https://github.com/nq-rdl/agent-extensions)
+to package and install skills into the target agent environment.
+
+## Repo Layout
+
+- `skills/`: self-contained skill directories
+- `docs/`: specification and authoring documentation
+- `src/skills/ref/`: reference validation and prompt-generation code
+- `tests/`: tests for the reference tooling
+
+## Validation
+
+Validate all skills in the repo:
+
+```bash
+pixi run validate-skills
+```
+
+Validate a single skill:
+
+```bash
+ref validate skills/<skill-name>
+```

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -4,17 +4,17 @@ icon: lucide/book-open
 
 # Skills Catalog
 
-Portable, provider-agnostic skills following the [agentskills.io specification](https://agentskills.io/specification). Each skill is a directory under `skills/` containing a `SKILL.md` with YAML frontmatter and markdown instructions.
+Portable, provider-agnostic skills following the [agentskills.io specification](https://agentskills.io/specification). Each skill is self-contained: a directory under `skills/` with a `SKILL.md` plus any optional scripts, references, templates, or assets it needs.
 
-## Installation
+This repo documents and validates those skills. The repo-specific structure used here is outlined in [`specification.mdx`](specification.mdx).
 
-Skills are discovered automatically when placed in the standard locations:
+## Repo Scope
 
-| Scope | Path |
-|-------|------|
-| Project | `<project>/.agents/skills/<name>/` |
-| User | `~/.agents/skills/<name>/` |
-| Client-specific | `~/.<client>/skills/<name>/` |
+This repository is for authoring skills and maintaining the reference tooling around them.
+
+It is not the packaging or installation layer.
+
+RDL uses [nq-rdl/agent-extensions](https://github.com/nq-rdl/agent-extensions) to package and install skills into target agent environments.
 
 ## Skill Index
 


### PR DESCRIPTION
## Summary
- add a root README that explains the repo's purpose and frames each skill as a self-contained unit
- link the repo to the Agent Skills Specification and the local `docs/specification.mdx` guidance
- clarify that packaging and installation happen via `nq-rdl/agent-extensions`, not in this repo

## Testing
- not run (docs-only changes)