### PR TITLE
feat: add release workflow and docs contributing symlink

### DIFF
--- a/.changes/unreleased/Added-20260404-183054.yaml
+++ b/.changes/unreleased/Added-20260404-183054.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Tag-triggered release workflow with automatic changie batch and GitHub release
+time: 2026-04-04T18:30:54.871748923+10:00

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Verify tag points to a commit on main
+        env:
+          SHA: ${{ github.sha }}
+        run: |
+          git fetch origin main --depth=1
+          if ! git merge-base --is-ancestor "$SHA" origin/main; then
+            echo "::error::Release tags must point to commits already on main."
+            exit 1
+          fi
+
+      - name: Install changie
+        uses: miniscruff/changie-action@v2
+        with:
+          version: latest
+
+      - name: Batch and merge changelog
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          version="${TAG#v}"
+          changie batch "$version"
+          changie merge
+
+      - name: Commit changelog updates
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .changes/ CHANGELOG.md
+          git commit -m "chore: update changelog for ${TAG}"
+          git push origin HEAD:main
+
+      - name: Prepare release notes
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          version="${TAG#v}"
+          cp ".changes/${version}.md" release-notes.md
+
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          body_path: release-notes.md
+          generate_release_notes: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,7 +113,3 @@ pixi run lint               # ruff lint
 pixi run test               # pytest
 pixi run hooks-run          # run all pre-commit hooks
 ```
-
-## Code of Conduct
-
-Be respectful and constructive. We're all here to build useful agent skills.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,0 +1,1 @@
+../CONTRIBUTING.md


### PR DESCRIPTION
## Summary

- Add **release.yml** workflow: on `v*` tag push, verifies tag is on main, runs `changie batch` + `changie merge`, commits changelog back to main, and creates a GitHub release with the version notes
- Remove Code of Conduct section from **CONTRIBUTING.md**
- Symlink **docs/contributing.md** → `../CONTRIBUTING.md` for docs site inclusion

## Release flow

```
git tag v0.1.0
git push origin v0.1.0
```

CI then: verify tag → changie batch 0.1.0 → changie merge → commit CHANGELOG.md → create GitHub release with `.changes/0.1.0.md` as body.

## Test plan

- [ ] Verify release workflow YAML is valid
- [ ] Confirm `docs/contributing.md` symlink resolves correctly
- [ ] After merge, test release flow with a `v0.1.0` tag