### PR TITLE
chore: prevent Python cache recommits

### DIFF
--- a/.changes/unreleased/Fixed-20260404-183753.yaml
+++ b/.changes/unreleased/Fixed-20260404-183753.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Prevent Python cache artifacts from being recommitted to the repository
+time: 2026-04-04T18:37:53+10:00

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 __pycache__/
 *.pyc
 *.pyo
+.pytest_cache/
+.ruff_cache/
 *.egg-info/
 dist/
 build/


### PR DESCRIPTION
## Summary
- add explicit repo-level ignores for `.pytest_cache/` and `.ruff_cache/` alongside the existing `__pycache__` and `*.pyc` rules
- add a changie `Fixed` fragment documenting the cache-artifact cleanup
- keep Python cache files from being accidentally recommitted after the earlier cleanup already removed tracked `__pycache__` files from `main`