### PR TITLE
fix: use GitHub App token for release workflow push to protected main

### DIFF
--- a/.changes/unreleased/Fixed-20260404-release-workflow.yaml
+++ b/.changes/unreleased/Fixed-20260404-release-workflow.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Release workflow failing to push changelog to protected main branch
+time: 2026-04-04T20:00:00.000000000+10:00

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Check out code
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Verify tag points to a commit on main
         env:


### PR DESCRIPTION
## Summary

- Fixes the release workflow failing to push changelog commits to `main` because branch protection blocks the default `GITHUB_TOKEN`
- Adds a `actions/create-github-app-token@v2` step that generates a short-lived App installation token
- Passes the token to `actions/checkout` so `git push` inherits bypass permissions

Closes #6

## Setup required before merging

1. Create an org-owned GitHub App with `contents: write` permission
2. Install it on `nq-rdl/agent-skills`
3. Add repo secrets:
   - `RELEASE_APP_ID` — the App's numeric ID
   - `RELEASE_APP_PRIVATE_KEY` — the App's private key (PEM)

## Test plan

- [x] Create the GitHub App and add secrets as above
- [x] Merge this PR
- [ ] Push a `v*` tag and verify the release workflow completes successfully