### PR TITLE
feat: add Jules dispatch workflows for security, review, and skills

### DIFF
--- a/.changes/unreleased/Added-20260406-jules-dispatches.yaml
+++ b/.changes/unreleased/Added-20260406-jules-dispatches.yaml
@@ -1,0 +1,5 @@
+kind: Added
+body: >-
+  Add Jules dispatch workflows for security review (@jules-security),
+  issue triage and spec writing (@jules-review), and skill
+  auditing/creation/fixing (@jules-skills).

--- a/.github/workflows/jules-review-dispatch.yml
+++ b/.github/workflows/jules-review-dispatch.yml
@@ -1,0 +1,166 @@
+name: Jules Issue Review
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    if: >
+      contains(github.event.comment.body, '@jules-review') &&
+      !contains(github.event.comment.body, '@jules-swe') &&
+      !contains(github.event.comment.body, '@jules-security') &&
+      !contains(github.event.comment.body, '@jules-docs') &&
+      !contains(github.event.comment.body, '@jules-infra') &&
+      !contains(github.event.comment.body, '@jules-skills') &&
+      contains(fromJSON('["OWNER", "MEMBER"]'), github.event.comment.author_association)
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Fetch issue context
+        id: issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh issue view "$ISSUE_NUMBER" \
+            --repo "$REPO" \
+            --json title,body,labels \
+            --jq '{title, body, labels: [.labels[].name]}' > /tmp/issue.json
+
+          ISSUE_TITLE=$(jq -r '.title' /tmp/issue.json)
+          ISSUE_BODY=$(jq -r '.body // "No description provided."' /tmp/issue.json)
+          ISSUE_LABELS=$(jq -r '.labels | join(", ")' /tmp/issue.json)
+
+          # Use random delimiters to prevent injection via crafted issue content
+          DELIM=$(openssl rand -hex 8)
+
+          {
+            echo "title<<$DELIM"
+            echo "$ISSUE_TITLE"
+            echo "$DELIM"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "body<<$DELIM"
+            echo "$ISSUE_BODY"
+            echo "$DELIM"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "labels<<$DELIM"
+            echo "$ISSUE_LABELS"
+            echo "$DELIM"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Invoke Jules — Issue Review
+        uses: nq-rdl/jules-action@d8ed19ed75a6c2a35fd4e06e5b2ca7cd68b27046  # pinned 2026-04-02
+        with:
+          jules_api_key: ${{ secrets.RJ_JULES_API }}
+          include_commit_log: true
+          require_plan_approval: false
+          title: "Review: ${{ steps.issue.outputs.title }}"
+          prompt: |
+            You are an Issue Reviewer for **agent-skills** — RDL's repository for authoring, documenting, and validating Agent Skills following the Agent Skills Specification.
+
+            Read `CONTRIBUTING.md` at the repo root for contribution conventions. Read `README.md` for project structure. Read `docs/specification.mdx` for the skill format specification.
+
+            ## Project context
+
+            This repo contains 40+ self-contained skills under `skills/`, each with a `SKILL.md` file containing YAML frontmatter and Markdown instructions. Skills may bundle `scripts/`, `references/`, and `assets/` directories. The validation tooling lives in `src/skills/ref/` (Python). CI runs `pixi run validate-skills` on every PR. Every PR requires a changie fragment in `.changes/unreleased/`.
+
+            ## Your role
+
+            You triage and analyze GitHub issues. Your job is to understand the request, assess its impact on the codebase, and produce a clear solution spec that a developer (human or AI) can implement from. You do NOT implement the solution — you define it.
+
+            ## Review process
+
+            ### 1. Understand the request
+            Read the issue carefully. Determine what category it falls into:
+            - **New skill**: request to add a skill to `skills/`
+            - **Skill bug**: existing skill has incorrect instructions, broken scripts, or stale references
+            - **Skill enhancement**: improve an existing skill's coverage, accuracy, or structure
+            - **Tooling change**: modify validation, parsing, or prompt generation in `src/skills/ref/`
+            - **CI/workflow change**: modify `.github/workflows/` or pre-commit hooks
+            - **Documentation**: update `docs/`, `README.md`, or `CONTRIBUTING.md`
+
+            ### 2. Assess impact
+            Read the affected files in the repo. Determine:
+            - **Scope**: which files and directories are affected
+            - **Risk**: could this break validation, CI, or existing skills?
+            - **Dependencies**: does this require changes in multiple places?
+            - **Effort estimate**: small (< 1 hour), medium (1-4 hours), large (> 4 hours)
+
+            ### 3. Outline solution
+            Write a concrete solution outline with:
+            - Specific files to create or modify (with paths)
+            - What changes are needed in each file
+            - Any edge cases or constraints to respect
+            - Validation steps to confirm the change works
+
+            ### 4. Write the spec
+            Create a spec file at `spec/<issue-number>-<slug>.md` with this structure:
+
+            ```markdown
+            # Issue #<number>: <title>
+
+            ## Summary
+            <1-2 sentence description of what was requested>
+
+            ## Category
+            <one of: new-skill | skill-bug | skill-enhancement | tooling | ci-workflow | documentation>
+
+            ## Impact Assessment
+            - **Scope**: <files/directories affected>
+            - **Risk**: <low | medium | high> — <why>
+            - **Effort**: <small | medium | large>
+            - **Dependencies**: <any cross-cutting concerns>
+
+            ## Solution
+
+            ### Approach
+            <description of the recommended approach>
+
+            ### Changes
+            <ordered list of specific file changes>
+
+            ### Validation
+            <how to verify the change works — commands, test cases, manual checks>
+
+            ## Open Questions
+            <anything that needs clarification before implementation>
+            ```
+
+            ## GitHub Issue #${{ github.event.issue.number }}: ${{ steps.issue.outputs.title }}
+
+            Labels: ${{ steps.issue.outputs.labels }}
+
+            ${{ steps.issue.outputs.body }}
+
+            ## Triggering comment
+
+            ${{ github.event.comment.body }}
+
+            ## Instructions
+
+            Review the issue above. Read the relevant source files to understand the current state. Produce the spec file at `spec/${{ github.event.issue.number }}-<slug>.md` where `<slug>` is a short kebab-case summary derived from the issue title.
+
+            If the issue is unclear or missing critical information, note this in the "Open Questions" section of the spec rather than guessing.
+
+            Add a changie fragment in `.changes/unreleased/` with kind `Added` describing the spec.
+
+            Open a pull request with the spec when complete.
+
+      - name: React to confirm dispatch
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api "repos/$REPO/issues/comments/$COMMENT_ID/reactions" \
+            -X POST -f content='rocket'

--- a/.github/workflows/jules-security-dispatch.yml
+++ b/.github/workflows/jules-security-dispatch.yml
@@ -1,0 +1,137 @@
+name: Jules Security Review
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  security-review:
+    runs-on: ubuntu-latest
+    if: >
+      contains(github.event.comment.body, '@jules-security') &&
+      !contains(github.event.comment.body, '@jules-swe') &&
+      !contains(github.event.comment.body, '@jules-docs') &&
+      !contains(github.event.comment.body, '@jules-infra') &&
+      !contains(github.event.comment.body, '@jules-review') &&
+      !contains(github.event.comment.body, '@jules-skills') &&
+      contains(fromJSON('["OWNER", "MEMBER"]'), github.event.comment.author_association)
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Fetch issue context
+        id: issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh issue view "$ISSUE_NUMBER" \
+            --repo "$REPO" \
+            --json title,body,labels \
+            --jq '{title, body, labels: [.labels[].name]}' > /tmp/issue.json
+
+          ISSUE_TITLE=$(jq -r '.title' /tmp/issue.json)
+          ISSUE_BODY=$(jq -r '.body // "No description provided."' /tmp/issue.json)
+          ISSUE_LABELS=$(jq -r '.labels | join(", ")' /tmp/issue.json)
+
+          # Use random delimiters to prevent injection via crafted issue content
+          DELIM=$(openssl rand -hex 8)
+
+          {
+            echo "title<<$DELIM"
+            echo "$ISSUE_TITLE"
+            echo "$DELIM"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "body<<$DELIM"
+            echo "$ISSUE_BODY"
+            echo "$DELIM"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "labels<<$DELIM"
+            echo "$ISSUE_LABELS"
+            echo "$DELIM"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Detect PR branch
+        id: branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          # PR comments arrive as issue_comment events — check if it's a PR
+          BRANCH=$(gh pr view "$ISSUE_NUMBER" --repo "$REPO" \
+            --json headRefName --jq '.headRefName' 2>/dev/null || echo "main")
+          echo "name=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Invoke Jules — Security Review
+        uses: nq-rdl/jules-action@d8ed19ed75a6c2a35fd4e06e5b2ca7cd68b27046  # pinned 2026-04-02
+        with:
+          jules_api_key: ${{ secrets.RJ_JULES_API }}
+          starting_branch: ${{ steps.branch.outputs.name }}
+          include_commit_log: true
+          require_plan_approval: false
+          title: "Security: ${{ steps.issue.outputs.title }}"
+          prompt: |
+            You are a Security Reviewer for **agent-skills** — RDL's repository for authoring, documenting, and validating Agent Skills following the Agent Skills Specification.
+
+            Read `CONTRIBUTING.md` at the repo root for contribution conventions. Read `README.md` for project structure. Read `docs/specification.mdx` for the skill format specification.
+
+            ## Project context
+
+            This repo contains 40+ self-contained skills under `skills/`, each with a `SKILL.md` file containing YAML frontmatter and Markdown instructions. Skills may bundle `scripts/`, `references/`, and `assets/` directories. The validation tooling lives in `src/skills/ref/` (Python). CI runs `pixi run validate-skills` on every PR.
+
+            ## Risk patterns for this stack
+
+            - **SKILL.md injection**: Skills contain instructions that LLMs execute. A malicious or poorly written skill could inject prompt content that causes unintended behavior in the consuming agent. Check for prompt injection vectors in skill instructions.
+            - **Script execution**: Skills may bundle executable scripts under `scripts/`. These run in user environments — check for command injection, path traversal, unsafe shell expansion, or unvalidated external input.
+            - **YAML frontmatter parsing**: The validation tooling in `src/skills/ref/` parses YAML frontmatter. Check for YAML deserialization risks, unconstrained input lengths, or regex denial-of-service patterns.
+            - **CI/CD pipeline security**: GitHub Actions workflows in `.github/workflows/` use secrets and run on PR events. Check for secret leakage, unsafe `pull_request_target` usage, or injection via PR titles/bodies into shell commands.
+            - **Dependency supply chain**: `pyproject.toml` and `pixi.lock` control dependencies. Check for unpinned dependencies, suspicious packages, or lock file integrity.
+            - **Reference file exfiltration**: Skills can reference external URLs or files. Check for data exfiltration vectors through skill instructions that direct agents to send data to external endpoints.
+
+            ## Severity classification
+
+            - **CRITICAL**: Direct code execution, secret leakage, or supply chain compromise
+            - **HIGH**: Prompt injection that could bypass safety controls, path traversal to sensitive files
+            - **MEDIUM**: Unsafe defaults, missing input validation at trust boundaries, overly broad permissions
+            - **LOW**: Informational findings, hardening recommendations, defense-in-depth suggestions
+
+            ## GitHub Issue #${{ github.event.issue.number }}: ${{ steps.issue.outputs.title }}
+
+            Labels: ${{ steps.issue.outputs.labels }}
+
+            ${{ steps.issue.outputs.body }}
+
+            ## Triggering comment
+
+            ${{ github.event.comment.body }}
+
+            ## Instructions
+
+            Perform the security review described in the issue. For each finding:
+            1. State the severity (CRITICAL / HIGH / MEDIUM / LOW)
+            2. Identify the affected file(s) and line(s)
+            3. Describe the vulnerability and attack scenario
+            4. Provide a concrete fix or mitigation
+
+            If fixes are straightforward, implement them. For complex findings that need design discussion, document them clearly but do not attempt speculative fixes.
+
+            Add a changie fragment in `.changes/unreleased/` with kind `Fixed` for any security fixes applied.
+
+            Open a pull request with your findings and any fixes when complete.
+
+      - name: React to confirm dispatch
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api "repos/$REPO/issues/comments/$COMMENT_ID/reactions" \
+            -X POST -f content='rocket'

--- a/.github/workflows/jules-skills-dispatch.yml
+++ b/.github/workflows/jules-skills-dispatch.yml
@@ -1,0 +1,186 @@
+name: Jules Skills Dispatch
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  skills:
+    runs-on: ubuntu-latest
+    if: >
+      contains(github.event.comment.body, '@jules-skills') &&
+      !contains(github.event.comment.body, '@jules-swe') &&
+      !contains(github.event.comment.body, '@jules-security') &&
+      !contains(github.event.comment.body, '@jules-docs') &&
+      !contains(github.event.comment.body, '@jules-infra') &&
+      !contains(github.event.comment.body, '@jules-review') &&
+      contains(fromJSON('["OWNER", "MEMBER"]'), github.event.comment.author_association)
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Fetch issue context
+        id: issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh issue view "$ISSUE_NUMBER" \
+            --repo "$REPO" \
+            --json title,body,labels \
+            --jq '{title, body, labels: [.labels[].name]}' > /tmp/issue.json
+
+          ISSUE_TITLE=$(jq -r '.title' /tmp/issue.json)
+          ISSUE_BODY=$(jq -r '.body // "No description provided."' /tmp/issue.json)
+          ISSUE_LABELS=$(jq -r '.labels | join(", ")' /tmp/issue.json)
+
+          # Use random delimiters to prevent injection via crafted issue content
+          DELIM=$(openssl rand -hex 8)
+
+          {
+            echo "title<<$DELIM"
+            echo "$ISSUE_TITLE"
+            echo "$DELIM"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "body<<$DELIM"
+            echo "$ISSUE_BODY"
+            echo "$DELIM"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "labels<<$DELIM"
+            echo "$ISSUE_LABELS"
+            echo "$DELIM"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Invoke Jules — Skills
+        uses: nq-rdl/jules-action@d8ed19ed75a6c2a35fd4e06e5b2ca7cd68b27046  # pinned 2026-04-02
+        with:
+          jules_api_key: ${{ secrets.RJ_JULES_API }}
+          include_commit_log: true
+          require_plan_approval: false
+          title: "Skills: ${{ steps.issue.outputs.title }}"
+          prompt: |
+            You are a Skill Engineer for **agent-skills** — RDL's repository for authoring, documenting, and validating Agent Skills following the Agent Skills Specification.
+
+            Read `CONTRIBUTING.md` for contribution conventions. Read `README.md` for project structure. Read `docs/specification.mdx` for the full format spec.
+
+            ## What is a skill?
+
+            A skill is a self-contained directory under `skills/` that teaches an AI agent how to perform a specific task. Skills are portable — they work across different agent implementations.
+
+            ```
+            skills/<skill-name>/
+            ├── SKILL.md          # Required: YAML frontmatter + Markdown instructions
+            ├── scripts/          # Optional: executable code agents can run
+            ├── references/       # Optional: docs agents load on demand
+            └── assets/           # Optional: templates, schemas, static resources
+            ```
+
+            ## SKILL.md format
+
+            Every skill requires a `SKILL.md` with YAML frontmatter:
+
+            ```yaml
+            ---
+            name: skill-name            # Required. Lowercase, hyphens only. Max 64 chars.
+            description: >-             # Required. Max 1024 chars. What it does + when to trigger.
+              Describe what the skill does and when to use it.
+              Include keywords that help agents match tasks to this skill.
+            license: MIT                # Optional.
+            compatibility: >-           # Optional. Max 500 chars. Environment requirements.
+              Requires Python 3.11+
+            metadata:                   # Optional. Arbitrary key-value pairs.
+              repo: https://github.com/nq-rdl/agent-skills
+            ---
+
+            # Skill Title
+
+            Markdown instructions follow the frontmatter...
+            ```
+
+            ### Validation rules (enforced by CI)
+
+            - `name`: lowercase alphanumeric + hyphens, no leading/trailing/consecutive hyphens, must match parent directory name, max 64 chars
+            - `description`: non-empty, max 1024 chars — should describe both what the skill does AND when to use it
+            - `compatibility`: if present, max 500 chars
+            - Only these frontmatter fields are allowed: `name`, `description`, `license`, `compatibility`, `metadata`, `allowed-tools`
+            - Validate locally with: `pixi run validate-skills`
+
+            ### Writing effective skills
+
+            - **Description is the trigger**: agents see name + description in their skill list and decide whether to activate. Make descriptions specific with action keywords.
+            - **Progressive disclosure**: keep SKILL.md under 500 lines. Move detailed references to `references/` files and point to them from SKILL.md.
+            - **Explain the why**: instead of rigid MUST/NEVER rules, explain reasoning so the agent can handle edge cases intelligently.
+            - **Include examples**: show concrete input/output pairs when the skill has a defined format.
+            - **Scripts for repeatability**: if agents would independently write the same helper script each time, bundle it in `scripts/`.
+            - **No hooks or platform imports**: skills must be portable. Platform-specific behavior belongs in the extensions layer, not in skills.
+
+            ## Existing skills to study
+
+            Before creating or modifying a skill, read 2-3 existing skills for patterns:
+            - `skills/dispatch/SKILL.md` — clean pattern: when-to-use table, decision tree, error handling
+            - `skills/tdd/SKILL.md` — structured workflow: red/green/refactor steps
+            - `skills/go-naming/SKILL.md` — reference style: conventions with rationale
+            - `skills/cc-hooks/SKILL.md` — integration pattern: teaches agents to use a specific tool
+
+            ## Task types
+
+            You handle three kinds of skill work:
+
+            ### Audit
+            Review an existing skill for correctness and quality:
+            - Does the frontmatter pass validation? (run `pixi run validate-skills` mentally against the rules above)
+            - Is the description specific enough to trigger appropriately?
+            - Are instructions accurate against current APIs/tools? (read referenced docs, check script correctness)
+            - Is SKILL.md under 500 lines with heavy content in `references/`?
+            - Are scripts self-contained with clear error messages?
+            - Are there stale references to renamed files, removed commands, or changed APIs?
+
+            ### New skill
+            Create a new skill from a request:
+            1. Create `skills/<name>/SKILL.md` with valid frontmatter
+            2. Write clear, structured instructions in the Markdown body
+            3. Add `scripts/`, `references/`, `assets/` only if needed
+            4. Verify the skill passes validation rules listed above
+            5. Study similar existing skills for structural patterns
+
+            ### Fix
+            Repair a broken or degraded skill:
+            - Identify the specific issue (stale instructions, broken script, invalid frontmatter, poor description)
+            - Fix it with minimal changes — don't rewrite a skill that mostly works
+            - If a script is broken, test-fix the script; don't remove it and inline the logic
+
+            ## GitHub Issue #${{ github.event.issue.number }}: ${{ steps.issue.outputs.title }}
+
+            Labels: ${{ steps.issue.outputs.labels }}
+
+            ${{ steps.issue.outputs.body }}
+
+            ## Triggering comment
+
+            ${{ github.event.comment.body }}
+
+            ## Instructions
+
+            Perform the skill work described in the issue. Read the affected skill(s) and any referenced files before making changes.
+
+            Ensure all modified or created skills pass the validation rules above. The directory name must match the `name` field in frontmatter.
+
+            Add a changie fragment in `.changes/unreleased/` with the appropriate kind (`Added` for new skills, `Fixed` for fixes, `Changed` for improvements).
+
+            Open a pull request when complete.
+
+      - name: React to confirm dispatch
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh api "repos/$REPO/issues/comments/$COMMENT_ID/reactions" \
+            -X POST -f content='rocket'


### PR DESCRIPTION
## Summary

- Adds `@jules-security` dispatch — security review with stack-specific risk patterns and severity classification
- Adds `@jules-review` dispatch — issue triage, impact assessment, and solution spec writing to `spec/`
- Adds `@jules-skills` dispatch — skill auditing, creation, and fixing with the full Agent Skills Specification injected into the prompt (Jules has no native skill system)

## Security

- All workflows restrict to **OWNER/MEMBER only** (no COLLABORATOR)
- Random heredoc delimiters on all `$GITHUB_OUTPUT` writes (title, body, **and labels** — fixes a pre-existing gap in the template pattern)
- Jules action pinned to commit SHA `d8ed19ed75a6c2a35fd4e06e5b2ca7cd68b27046`
- Full 6-handle `!contains` guards prevent double-firing
- All secrets passed via `env:` or `with:` — never interpolated into `run:` blocks

## Handle set

| Handle | Role |
|--------|------|
| `@jules-swe` | General engineering (existing template) |
| `@jules-security` | Security review — **new** |
| `@jules-docs` | Documentation (existing template) |
| `@jules-infra` | Infrastructure (existing template) |
| `@jules-review` | Issue triage + spec writing — **new** |
| `@jules-skills` | Skill audit/create/fix — **new** |

## Test plan

- [ ] Verify CI passes (skill validation + changelog check)
- [ ] Confirm `RJ_JULES_API` secret exists in repo settings
- [ ] Test `@jules-security` on a security-labeled issue
- [ ] Test `@jules-review` on a feature request issue — confirm spec written to `spec/`
- [ ] Test `@jules-skills` on a skill bug issue — confirm valid SKILL.md output
- [ ] Verify no double-firing when a comment mentions multiple handles