### PR TITLE
feat(pi-rpc): add configurable session timeout

### DIFF
--- a/.changes/unreleased/Added-21-timeout.yaml
+++ b/.changes/unreleased/Added-21-timeout.yaml
@@ -1,0 +1,2 @@
+kind: Added
+body: Add configurable timeout_seconds parameter to CreateRequest to override the default 60s inactivity timeout

--- a/skills/pi-rpc/scripts/cmd/pi-cli/session.go
+++ b/skills/pi-rpc/scripts/cmd/pi-cli/session.go
@@ -115,6 +115,7 @@ func newSessionCreateCmd(serverFlag *string) *cobra.Command {
 		model         string
 		cwd           string
 		thinkingLevel string
+		timeout       int32
 	)
 
 	cmd := &cobra.Command{
@@ -127,7 +128,7 @@ If --provider and --model are omitted, defaults (or PI_DEFAULT_PROVIDER/PI_DEFAU
 Tip: validate your provider/model pair before creating sessions:
   pi --provider <PROVIDER> --model <MODEL> --mode json "Reply with OK."`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runSessionCreate(cmd.Context(), serverURL(*serverFlag), provider, model, cwd, thinkingLevel)
+			return runSessionCreate(cmd.Context(), serverURL(*serverFlag), provider, model, cwd, thinkingLevel, timeout)
 		},
 	}
 
@@ -135,16 +136,18 @@ Tip: validate your provider/model pair before creating sessions:
 	cmd.Flags().StringVar(&model, "model", "", "Model ID from pi --list-models")
 	cmd.Flags().StringVar(&cwd, "cwd", "", "Working directory for the agent (default: current directory)")
 	cmd.Flags().StringVar(&thinkingLevel, "thinking", "", "Thinking level: low, medium, high")
+	cmd.Flags().Int32Var(&timeout, "timeout", 0, "Inactivity timeout in seconds")
 
 	return cmd
 }
 
-func runSessionCreate(ctx context.Context, base, provider, model, cwd, thinkingLevel string) error {
-	req := map[string]string{
-		"provider":       provider,
-		"model":          model,
-		"cwd":            cwd,
-		"thinking_level": thinkingLevel,
+func runSessionCreate(ctx context.Context, base, provider, model, cwd, thinkingLevel string, timeout int32) error {
+	req := map[string]any{
+		"provider":        provider,
+		"model":           model,
+		"cwd":             cwd,
+		"thinking_level":  thinkingLevel,
+		"timeout_seconds": timeout,
 	}
 
 	var resp struct {

--- a/skills/pi-rpc/scripts/cmd/pi-cli/session_test.go
+++ b/skills/pi-rpc/scripts/cmd/pi-cli/session_test.go
@@ -67,7 +67,7 @@ func TestRunSessionCreate(t *testing.T) {
 
 	// runSessionCreate writes to stdout — we just verify no error is returned
 	// and the call succeeds against a real HTTP server.
-	if err := runSessionCreate(context.Background(), srv.URL, "anthropic", "claude-opus-4", "/tmp", ""); err != nil {
+	if err := runSessionCreate(context.Background(), srv.URL, "anthropic", "claude-opus-4", "/tmp", "", 0); err != nil {
 		t.Errorf("runSessionCreate failed: %v", err)
 	}
 }

--- a/skills/pi-rpc/scripts/gen/pirpc/v1/session.pb.go
+++ b/skills/pi-rpc/scripts/gen/pirpc/v1/session.pb.go
@@ -224,8 +224,10 @@ type CreateRequest struct {
 	Cwd string `protobuf:"bytes,3,opt,name=cwd,proto3" json:"cwd,omitempty"`
 	// Optional thinking level ("off", "minimal", "low", "medium", "high").
 	ThinkingLevel string `protobuf:"bytes,4,opt,name=thinking_level,json=thinkingLevel,proto3" json:"thinking_level,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	// Optional session inactivity timeout in seconds.
+	TimeoutSeconds int32 `protobuf:"varint,5,opt,name=timeout_seconds,json=timeoutSeconds,proto3" json:"timeout_seconds,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *CreateRequest) Reset() {
@@ -284,6 +286,13 @@ func (x *CreateRequest) GetThinkingLevel() string {
 		return x.ThinkingLevel
 	}
 	return ""
+}
+
+func (x *CreateRequest) GetTimeoutSeconds() int32 {
+	if x != nil {
+		return x.TimeoutSeconds
+	}
+	return 0
 }
 
 type CreateResponse struct {
@@ -1371,12 +1380,13 @@ var File_pirpc_v1_session_proto protoreflect.FileDescriptor
 
 const file_pirpc_v1_session_proto_rawDesc = "" +
 	"\n" +
-	"\x16pirpc/v1/session.proto\x12\bpirpc.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"z\n" +
+	"\x16pirpc/v1/session.proto\x12\bpirpc.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\xa3\x01\n" +
 	"\rCreateRequest\x12\x1a\n" +
 	"\bprovider\x18\x01 \x01(\tR\bprovider\x12\x14\n" +
 	"\x05model\x18\x02 \x01(\tR\x05model\x12\x10\n" +
 	"\x03cwd\x18\x03 \x01(\tR\x03cwd\x12%\n" +
-	"\x0ethinking_level\x18\x04 \x01(\tR\rthinkingLevel\"]\n" +
+	"\x0ethinking_level\x18\x04 \x01(\tR\rthinkingLevel\x12'\n" +
+	"\x0ftimeout_seconds\x18\x05 \x01(\x05R\x0etimeoutSeconds\"]\n" +
 	"\x0eCreateResponse\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x12,\n" +

--- a/skills/pi-rpc/scripts/handler/session_handler.go
+++ b/skills/pi-rpc/scripts/handler/session_handler.go
@@ -48,7 +48,7 @@ func (h *SessionHandler) Create(ctx context.Context, req *connect.Request[pirpcv
 	if model == "" {
 		model = h.defaults.Model
 	}
-	id, err := h.mgr.Create(ctx, provider, model, req.Msg.Cwd, req.Msg.ThinkingLevel)
+	id, err := h.mgr.Create(ctx, provider, model, req.Msg.Cwd, req.Msg.ThinkingLevel, req.Msg.TimeoutSeconds)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("create session: %w", err))
 	}

--- a/skills/pi-rpc/scripts/proto/pirpc/v1/session.proto
+++ b/skills/pi-rpc/scripts/proto/pirpc/v1/session.proto
@@ -63,6 +63,9 @@ message CreateRequest {
 
   // Optional thinking level ("off", "minimal", "low", "medium", "high").
   string thinking_level = 4;
+
+  // Optional session inactivity timeout in seconds.
+  int32 timeout_seconds = 5;
 }
 
 message CreateResponse {

--- a/skills/pi-rpc/scripts/session/manager.go
+++ b/skills/pi-rpc/scripts/session/manager.go
@@ -35,7 +35,7 @@ func NewManager(binary string) *Manager {
 }
 
 // Create spawns a new session subprocess and adds it to the manager.
-func (m *Manager) Create(ctx context.Context, provider, model, cwd, thinkingLevel string) (string, error) {
+func (m *Manager) Create(ctx context.Context, provider, model, cwd, thinkingLevel string, timeoutSeconds int32) (string, error) {
 	sessionCtx := context.Background()
 	if ctx != nil {
 		sessionCtx = context.WithoutCancel(ctx)
@@ -52,12 +52,13 @@ func (m *Manager) Create(ctx context.Context, provider, model, cwd, thinkingLeve
 	}
 
 	s, err := NewSession(sessionCtx, Config{
-		Binary:        m.binary,
-		Args:          args,
-		Provider:      provider,
-		Model:         model,
-		Cwd:           cwd,
-		ThinkingLevel: thinkingLevel,
+		Binary:            m.binary,
+		Args:              args,
+		Provider:          provider,
+		Model:             model,
+		Cwd:               cwd,
+		ThinkingLevel:     thinkingLevel,
+		InactivityTimeout: time.Duration(timeoutSeconds) * time.Second,
 	})
 	if err != nil {
 		return "", err

--- a/spec/21-60s-inactivity-timeout-kills-sessions.md
+++ b/spec/21-60s-inactivity-timeout-kills-sessions.md
@@ -1,0 +1,32 @@
+# Issue 21: 60s inactivity timeout kills sessions before slow providers respond to long prompts
+
+## Summary
+The 60s inactivity timeout in `Session` terminates the session if a response doesn't come back in time. This is problematic for slow providers or long prompts.
+
+## Category
+Bug/Feature
+
+## Impact Assessment
+- Scope: `Session` creation and configuration.
+- Risk: Low.
+- Effort: Low.
+- Dependencies: None.
+
+## Solution
+### Approach
+1. Add an optional `timeout_seconds` parameter to the `CreateRequest` Protobuf message in `skills/pi-rpc/scripts/proto/pirpc/v1/session.proto`.
+2. Regenerate the Protobuf code using `make generate` in `skills/pi-rpc/scripts`.
+3. Update `SessionHandler.Create` in `skills/pi-rpc/scripts/handler/session_handler.go` to extract `timeout_seconds` and pass it down.
+4. Update `Manager.Create` in `skills/pi-rpc/scripts/session/manager.go` to accept the timeout parameter and set it in `session.Config.InactivityTimeout`.
+
+### Changes
+- `skills/pi-rpc/scripts/proto/pirpc/v1/session.proto`
+- `skills/pi-rpc/scripts/handler/session_handler.go`
+- `skills/pi-rpc/scripts/session/manager.go`
+
+### Validation
+- Verify that a `CreateRequest` with `timeout_seconds` correctly configures the timeout.
+- Test that the session does not timeout earlier than `timeout_seconds`.
+
+## Open Questions
+None.


### PR DESCRIPTION
Adds an optional `timeout_seconds` parameter to the `CreateRequest` Protobuf message, which maps to the underlying subprocess `Session`'s inactivity timeout. The `pi-cli session create` command also accepts an optional `--timeout` flag. This fixes an issue where the hardcoded 60s inactivity timeout kills sessions too early for slow providers.

---
*PR created automatically by Jules for task [6792175935275966127](https://jules.google.com/task/6792175935275966127) started by @rudolfjs*