### PR TITLE
Fix missing API key error masking and default to openai-codex

### DIFF
--- a/.changes/unreleased/Added-20260407-120927.yaml
+++ b/.changes/unreleased/Added-20260407-120927.yaml
@@ -1,0 +1,2 @@
+kind: Added
+body: Add solution spec for pi-rpc provider mismatch and error masking issue (Issue #22)

--- a/.changes/unreleased/Fixed-20260408-pi-rpc-issue-22.yaml
+++ b/.changes/unreleased/Fixed-20260408-pi-rpc-issue-22.yaml
@@ -1,0 +1,2 @@
+kind: Fixed
+body: "[skill:pi-rpc] Fix missing API key error masking and default to openai-codex when authenticated via OAuth"

--- a/skills/pi-rpc/scripts/cmd/pi-cli/serve.go
+++ b/skills/pi-rpc/scripts/cmd/pi-cli/serve.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 
 	"github.com/spf13/cobra"
@@ -15,6 +17,30 @@ import (
 	"github.com/nq-rdl/agent-skills/skills/pi-rpc/scripts/handler"
 	"github.com/nq-rdl/agent-skills/skills/pi-rpc/scripts/session"
 )
+
+func autoDetectProvider() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "openai"
+	}
+
+	authFile := filepath.Join(home, ".pi", "agent", "auth.json")
+	data, err := os.ReadFile(authFile)
+	if err != nil {
+		return "openai"
+	}
+
+	var authData map[string]interface{}
+	if err := json.Unmarshal(data, &authData); err != nil {
+		return "openai"
+	}
+
+	if _, ok := authData["openai-codex"]; ok {
+		return "openai-codex"
+	}
+
+	return "openai"
+}
 
 func newServeCmd() *cobra.Command {
 	var (
@@ -35,7 +61,7 @@ on demand. Agents communicate with it via the session subcommands.
 Environment variables:
   PI_SERVER_PORT       Override the listening port (default: 4097)
   PI_BINARY            Path to the pi binary (default: pi)
-  PI_DEFAULT_PROVIDER  Fallback provider when Create omits it (default: openai)
+  PI_DEFAULT_PROVIDER  Fallback provider when Create omits it (default: auto-detected or openai)
   PI_DEFAULT_MODEL     Fallback model when Create omits it (default: gpt-4.1)`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runServe(port, binary, defaultProvider, defaultModel)
@@ -44,7 +70,7 @@ Environment variables:
 
 	cmd.Flags().StringVar(&port, "port", "", "Listening port (overrides PI_SERVER_PORT, default: 4097)")
 	cmd.Flags().StringVar(&binary, "binary", "", "Path to pi binary (overrides PI_BINARY, default: pi)")
-	cmd.Flags().StringVar(&defaultProvider, "default-provider", "", "Fallback provider (overrides PI_DEFAULT_PROVIDER, default: openai)")
+	cmd.Flags().StringVar(&defaultProvider, "default-provider", "", "Fallback provider (overrides PI_DEFAULT_PROVIDER, default: auto-detected or openai)")
 	cmd.Flags().StringVar(&defaultModel, "default-model", "", "Fallback model (overrides PI_DEFAULT_MODEL, default: gpt-4.1)")
 
 	return cmd
@@ -72,7 +98,7 @@ func runServe(portFlag, binaryFlag, defaultProviderFlag, defaultModelFlag string
 		defaultProvider = os.Getenv("PI_DEFAULT_PROVIDER")
 	}
 	if defaultProvider == "" {
-		defaultProvider = "openai"
+		defaultProvider = autoDetectProvider()
 	}
 
 	defaultModel := defaultModelFlag

--- a/skills/pi-rpc/scripts/cmd/pi-server/main.go
+++ b/skills/pi-rpc/scripts/cmd/pi-server/main.go
@@ -1,17 +1,43 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 
 	"github.com/nq-rdl/agent-skills/skills/pi-rpc/scripts/gen/pirpc/v1/pirpcv1connect"
 	"github.com/nq-rdl/agent-skills/skills/pi-rpc/scripts/handler"
 	"github.com/nq-rdl/agent-skills/skills/pi-rpc/scripts/session"
 )
+
+func autoDetectProvider() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "openai"
+	}
+
+	authFile := filepath.Join(home, ".pi", "agent", "auth.json")
+	data, err := os.ReadFile(authFile)
+	if err != nil {
+		return "openai"
+	}
+
+	var authData map[string]interface{}
+	if err := json.Unmarshal(data, &authData); err != nil {
+		return "openai"
+	}
+
+	if _, ok := authData["openai-codex"]; ok {
+		return "openai-codex"
+	}
+
+	return "openai"
+}
 
 func main() {
 	port := os.Getenv("PI_SERVER_PORT")
@@ -21,7 +47,7 @@ func main() {
 
 	defaultProvider := os.Getenv("PI_DEFAULT_PROVIDER")
 	if defaultProvider == "" {
-		defaultProvider = "openai"
+		defaultProvider = autoDetectProvider()
 	}
 	defaultModel := os.Getenv("PI_DEFAULT_MODEL")
 	if defaultModel == "" {

--- a/skills/pi-rpc/scripts/session/session.go
+++ b/skills/pi-rpc/scripts/session/session.go
@@ -270,10 +270,15 @@ func (s *Session) monitorInactivity() {
 				s.mu.Lock()
 				if s.state == StateRunning {
 					s.state = StateError
-					s.errorMsg = fmt.Sprintf(
+					timeoutMsg := fmt.Sprintf(
 						"session killed: no activity for %s (provider=%s, model=%s)",
 						s.inactivityTimeout, s.provider, s.model,
 					)
+					if s.errorMsg == "" {
+						s.errorMsg = timeoutMsg
+					} else {
+						s.errorMsg = s.errorMsg + "\n" + timeoutMsg
+					}
 				}
 				s.mu.Unlock()
 

--- a/spec/22-pi-rpc-provider-mismatch.md
+++ b/spec/22-pi-rpc-provider-mismatch.md
@@ -1,0 +1,51 @@
+# Issue #22: [skill:pi-rpc] RPC server uses wrong provider name — `openai` vs `openai-codex` OAuth mismatch
+
+## Summary
+The pi-rpc server incorrectly defaults to the `openai` provider, which fails when the user has authenticated via OAuth (`openai-codex` provider). Furthermore, early subprocess failures (like missing API keys) are masked by the inactivity timeout monitor, which blindly overwrites the existing error message.
+
+## Category
+skill-bug
+
+## Impact Assessment
+- **Scope**: `skills/pi-rpc/scripts/cmd/pi-server/main.go`, `skills/pi-rpc/scripts/cmd/pi-cli/serve.go`, `skills/pi-rpc/scripts/session/session.go`.
+- **Risk**: Low — The changes only improve error reporting and sensible default detection without altering core agent execution.
+- **Effort**: Small — Consists of reading a local JSON file to detect the default provider and preventing the inactivity monitor from overwriting existing error messages.
+- **Dependencies**: None.
+
+## Solution
+
+### Approach
+1. **Auto-detect default provider**: Update `main.go` and `serve.go` to auto-detect the default provider by inspecting `~/.pi/agent/auth.json`. If the `openai-codex` key exists, default to `openai-codex`. If not (or if the file doesn't exist), fallback to `openai`.
+2. **Prevent error masking**: Update `session.go`'s `monitorInactivity` function. When it triggers a timeout, it currently overwrites `s.errorMsg` unconditionally. It should instead preserve any existing error message (such as "No API key found") so that authentic root causes are surfaced instead of misleading inactivity timeouts.
+
+### Changes
+1. **`skills/pi-rpc/scripts/cmd/pi-server/main.go` and `skills/pi-rpc/scripts/cmd/pi-cli/serve.go`**
+   - Implement an `autoDetectProvider()` helper function that reads `~/.pi/agent/auth.json`.
+   - If the file can be unmarshaled into a map and contains the key `openai-codex`, return `"openai-codex"`.
+   - Otherwise, return `"openai"`.
+   - Update the initialization of `defaultProvider` to use `autoDetectProvider()` when `os.Getenv("PI_DEFAULT_PROVIDER")` is empty.
+
+2. **`skills/pi-rpc/scripts/session/session.go`**
+   - In the `monitorInactivity` method, locate the block where `s.errorMsg` is assigned:
+     ```go
+     s.errorMsg = fmt.Sprintf("session killed: no activity for %s...", ...)
+     ```
+   - Modify it to check if `s.errorMsg` is already populated. If it is, append the timeout message rather than overwriting it, or keep the existing message as the primary error.
+     ```go
+     timeoutMsg := fmt.Sprintf("session killed: no activity for %s (provider=%s, model=%s)", s.inactivityTimeout, s.provider, s.model)
+     if s.errorMsg == "" {
+         s.errorMsg = timeoutMsg
+     } else {
+         s.errorMsg = s.errorMsg + "\n" + timeoutMsg
+     }
+     ```
+
+### Validation
+- Run `pixi run validate-skills` to ensure the skill specification remains valid.
+- Build the Go CLI and server: `cd skills/pi-rpc/scripts && make test build-cli build-server`.
+- Run tests (`make test`) to ensure no regressions in `session.go`.
+- Manually run `pi-cli serve` without setting `PI_DEFAULT_PROVIDER` and observe that it correctly defaults to `openai-codex` if `~/.pi/agent/auth.json` is configured appropriately.
+- Simulate a missing provider token and confirm that the resulting error message properly surfaces the "No API key found" message instead of only reporting an inactivity timeout.
+
+## Open Questions
+- Should `autoDetectProvider()` handle other potential provider names in the future? (Currently limiting scope to resolving the `openai` vs `openai-codex` mismatch).


### PR DESCRIPTION
Implements the solutions outlined in spec 22. Fixes issue with provider mismatch defaulting and inactivity timeouts masking early start up errors like missing API keys.

---
*PR created automatically by Jules for task [4706339446372494719](https://jules.google.com/task/4706339446372494719) started by @rudolfjs*