### PR TITLE
Add missing changelog fragment for gemini-cli model update

### DIFF
--- a/.changes/unreleased/Added-20260407-135734.yaml
+++ b/.changes/unreleased/Added-20260407-135734.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'feat(gemini-cli): add gemini-3.1-flash-lite-preview to model selection'
+time: 2026-04-07T13:57:34.372780979Z


### PR DESCRIPTION
This commit resolves the failing CI "Changelog Check" on the branch by adding an unreleased changelog fragment describing the addition of `gemini-3.1-flash-lite-preview` to `gemini-cli`.

---
*PR created automatically by Jules for task [11087265391912842075](https://jules.google.com/task/11087265391912842075) started by @rudolfjs*