### PR TITLE
Fix CI Changelog Check failure on feat/gemini-cli-flash-lite-model

### DIFF
--- a/.changes/unreleased/Changed-20260407-140935.yaml
+++ b/.changes/unreleased/Changed-20260407-140935.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: promote GEMINI_SYSTEM_MD with .gemini/prompts/ convention
+time: 2026-04-07T14:09:35.724456723Z


### PR DESCRIPTION
Added a changelog fragment in `.changes/unreleased/` to fix the CI `Changelog Check` failure on the `feat/gemini-cli-flash-lite-model` branch. The fragment describes the recent changes related to promoting the `GEMINI_SYSTEM_MD` with the `.gemini/prompts/` convention.

---
*PR created automatically by Jules for task [11559827988451495768](https://jules.google.com/task/11559827988451495768) started by @rudolfjs*