### PR TITLE
fix: release workflow tag drift, shallow fetch, and unreleased guard

### DIFF
--- a/.changes/unreleased/Fixed-20260408-release-tag-drift.yaml
+++ b/.changes/unreleased/Fixed-20260408-release-tag-drift.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Release workflow tag drift, shallow fetch, and missing unreleased changes guard
+time: 2026-04-08T12:00:00.000000000+10:00

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,9 +30,16 @@ jobs:
         env:
           SHA: ${{ github.sha }}
         run: |
-          git fetch origin main --depth=1
+          git fetch origin main
           if ! git merge-base --is-ancestor "$SHA" origin/main; then
             echo "::error::Release tags must point to commits already on main."
+            exit 1
+          fi
+
+      - name: Check for unreleased changes
+        run: |
+          if [ -z "$(ls .changes/unreleased/ 2>/dev/null | grep -v .gitkeep)" ]; then
+            echo "::error::No unreleased changelog entries found. Nothing to release."
             exit 1
           fi
 
@@ -58,6 +65,13 @@ jobs:
           git add .changes/ CHANGELOG.md
           git commit -m "chore: update changelog for ${TAG}"
           git push origin HEAD:main
+
+      - name: Move tag to include changelog commit
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          git tag -f "$TAG"
+          git push origin "$TAG" --force
 
       - name: Prepare release notes
         env:


### PR DESCRIPTION
## Summary
- **Shallow fetch fix**: Removed `--depth=1` from `git fetch origin main` so `merge-base --is-ancestor` works for any commit on main, not just the tip
- **Unreleased changes guard**: Added early check that fails fast with a clear error when no changelog entries exist in `.changes/unreleased/`, preventing empty releases
- **Tag re-pointing**: After the changelog commit is pushed to main, the release tag is force-moved to include it — fixes the issue where the tag (and GitHub Release) would point at a commit that doesn't contain its own changelog

## Test plan
- [ ] Merge this PR to main
- [ ] Push tag `v0.2.0` to trigger the release workflow
- [ ] Verify the workflow completes successfully
- [ ] Verify the GitHub Release body contains the changelog entries
- [ ] Verify the `v0.2.0` tag points at the changelog commit (not the commit before it)