### PR TITLE
feat: trigger agent-extensions sync on release

### DIFF
--- a/.changes/unreleased/Added-20260408-sync-dispatch.yaml
+++ b/.changes/unreleased/Added-20260408-sync-dispatch.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Release workflow triggers agent-extensions skill sync on each release
+time: 2026-04-08T15:30:00.000000000+10:00

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,3 +86,13 @@ jobs:
         with:
           body_path: release-notes.md
           generate_release_notes: false
+
+      - name: Trigger agent-extensions sync
+        env:
+          TAG: ${{ github.ref_name }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          gh api repos/nq-rdl/agent-extensions/dispatches \
+            --method POST \
+            --field event_type=agent-skills-release \
+            --field 'client_payload[tag]='"$TAG"


### PR DESCRIPTION
## Summary
- Add `repository_dispatch` step to release workflow that notifies agent-extensions to sync skills from the newly released tag
- Uses the app token (nq-rdl-release-bot) for cross-repo dispatch

## Test plan
- [ ] Merge both this PR and the corresponding agent-extensions PR
- [ ] Release as `v0.2.2` on agent-skills
- [ ] Verify agent-extensions receives the dispatch and creates a sync PR referencing the release tag