### PR TITLE
fix: scope app token for cross-repo dispatch

### DIFF
--- a/.changes/unreleased/Fixed-20260408-dispatch-token-scope.yaml
+++ b/.changes/unreleased/Fixed-20260408-dispatch-token-scope.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Release dispatch token scoped to both repos for cross-repo sync trigger
+time: 2026-04-08T15:45:00.000000000+10:00

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          repositories: agent-skills,agent-extensions
 
       - name: Check out code
         uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
- Add `repositories: agent-skills,agent-extensions` to app token generation
- The default token is scoped to the current repo only, causing a 403 on the dispatch call to agent-extensions

## Test plan
- [x] Merge and release as `v0.2.3`
- [x] Verify the dispatch step succeeds
- [x] Verify a sync PR appears in agent-extensions