### PR TITLE
fix(gemini-cli): update invalid approval mode flag to --yolo

### DIFF
--- a/.changes/unreleased/Fixed-gemini-cli-yolo-flag.yaml
+++ b/.changes/unreleased/Fixed-gemini-cli-yolo-flag.yaml
@@ -1,0 +1,2 @@
+kind: Fixed
+body: Update gemini-cli skill docs to use `--yolo` flag instead of invalid `--approval-mode yolo` flag

--- a/skills/gemini-cli/SKILL.md
+++ b/skills/gemini-cli/SKILL.md
@@ -47,10 +47,10 @@ Headless mode activates when `--prompt` is provided. Gemini runs, returns a resp
 ```bash
 gemini --prompt "Summarize the key risks in this architecture" \
   --output-format json \
-  --approval-mode yolo
+  --yolo
 ```
 
-`--approval-mode yolo` is **required** for headless — without it, Gemini blocks waiting for interactive confirmation that can never arrive.
+`--yolo` is **required** for headless — without it, Gemini blocks waiting for interactive confirmation that can never arrive.
 
 ### Output format
 
@@ -76,7 +76,7 @@ Use `--output-format stream-json` if you need the `session_id` for multi-turn (t
 
 ```bash
 git diff HEAD~1 | gemini --prompt "Review this diff. Focus on security issues." \
-  --approval-mode yolo --output-format json
+  --yolo --output-format json
 ```
 
 ### Multi-turn via `--resume`
@@ -86,13 +86,13 @@ Save the `session_id` from a previous call and continue the conversation:
 ```bash
 # First turn — capture session ID
 OUTPUT=$(gemini --prompt "Explain transformer attention" \
-  --output-format stream-json --approval-mode yolo)
+  --output-format stream-json --yolo)
 SESSION_ID=$(echo "$OUTPUT" | jq -r 'select(.type=="init") | .sessionId' | head -1)
 
 # Continue the session
 gemini --prompt "Compare to linear attention" \
   --resume "$SESSION_ID" \
-  --output-format json --approval-mode yolo
+  --output-format json --yolo
 ```
 
 ### System context injection
@@ -102,7 +102,7 @@ Use `GEMINI_SYSTEM_MD` to override the system prompt for a single call:
 ```bash
 GEMINI_SYSTEM_MD=.gemini/prompts/research-assistant.md \
   gemini --prompt "Find papers on MoE architectures" \
-  --approval-mode yolo --output-format json
+  --yolo --output-format json
 ```
 
 ---
@@ -193,7 +193,7 @@ Store prompts in `.gemini/prompts/` so they're versioned, discoverable, and easy
 # Set persona + output format for one call
 GEMINI_SYSTEM_MD=.gemini/prompts/security-auditor.md \
   gemini --prompt "Review this code" \
-  --approval-mode yolo --output-format json
+  --yolo --output-format json
 ```
 
 Where `.gemini/prompts/security-auditor.md` contains:
@@ -224,7 +224,7 @@ EOF
 
 gemini --prompt "Find papers on MoE architectures" \
   --include-directories "$TMPDIR" \
-  --approval-mode yolo --output-format json
+  --yolo --output-format json
 
 rm -rf "$TMPDIR"
 ```
@@ -242,10 +242,10 @@ Fire multiple headless processes concurrently — each is independent:
 ```bash
 # Start all searches in parallel
 gemini --prompt "Search the web for: latest MoE architecture papers 2025" \
-  --approval-mode yolo --output-format json &
+  --yolo --output-format json &
 
 gemini --prompt "Search the web for: transformer scaling laws survey 2025" \
-  --approval-mode yolo --output-format json &
+  --yolo --output-format json &
 
 wait  # collect results when both finish
 ```
@@ -255,20 +255,20 @@ wait  # collect results when both finish
 ```bash
 git diff HEAD~1 | gemini \
   --prompt "Review this diff. Focus on security issues and edge cases. Be concise." \
-  --approval-mode yolo --output-format json | jq -r '.response'
+  --yolo --output-format json | jq -r '.response'
 ```
 
 ### Multi-turn research with `--resume`
 
 ```bash
 OUTPUT=$(gemini --prompt "Explain transformer attention complexity" \
-  --output-format stream-json --approval-mode yolo)
+  --output-format stream-json --yolo)
 SESSION=$(echo "$OUTPUT" | jq -r 'select(.type=="init") | .sessionId' | head -1)
 RESPONSE=$(echo "$OUTPUT" | jq -r 'select(.type=="result") | .response' | head -1)
 
 # Drill down in the same session
 gemini --prompt "Compare the top 3 approaches by memory efficiency" \
-  --resume "$SESSION" --output-format json --approval-mode yolo | jq -r '.response'
+  --resume "$SESSION" --output-format json --yolo | jq -r '.response'
 ```
 
 ### Large output to file
@@ -276,14 +276,14 @@ gemini --prompt "Compare the top 3 approaches by memory efficiency" \
 ```bash
 cat large-document.pdf | gemini \
   --prompt "Convert this document to structured JSON" \
-  --approval-mode yolo --output-format json > /tmp/output.json
+  --yolo --output-format json > /tmp/output.json
 ```
 
 ---
 
 ## Defaults and Safety
 
-- `--approval-mode yolo` is required for headless — `default` blocks waiting for TTY confirmation
+- `--yolo` is required for headless — `default` blocks waiting for TTY confirmation
 - `--sandbox` is optional — Gemini CLI's sandbox sets `HOME=/home/node` internally, which requires a specific system setup. Disable unless your system supports it.
 - Default timeout: 5 minutes. For long tasks (large files, deep research), increase or use background processes.
 

--- a/skills/gemini-cli/references/automation.md
+++ b/skills/gemini-cli/references/automation.md
@@ -15,15 +15,15 @@ gemini -p "Write a haiku about TypeScript" --output-format json | jq -r '.respon
 ```bash
 # File analysis
 cat error.log | gemini -p "What's causing these errors? Give me the top 3 causes." \
-  --approval-mode yolo --output-format json | jq -r '.response'
+  --yolo --output-format json | jq -r '.response'
 
 # Git diff review
 git diff --staged | gemini -p "Write a conventional commit message for these changes." \
-  --approval-mode yolo --output-format json | jq -r '.response'
+  --yolo --output-format json | jq -r '.response'
 
 # Command output analysis
 kubectl get events --sort-by='.lastTimestamp' | \
-  gemini -p "Are there any concerning events?" --approval-mode yolo
+  gemini -p "Are there any concerning events?" --yolo
 ```
 
 ## Extract Session ID (for multi-turn)
@@ -31,7 +31,7 @@ kubectl get events --sort-by='.lastTimestamp' | \
 ```bash
 # Use stream-json to get session ID
 OUTPUT=$(gemini -p "Explain transformer attention" \
-  --output-format stream-json --approval-mode yolo)
+  --output-format stream-json --yolo)
 
 SESSION_ID=$(echo "$OUTPUT" | jq -r 'select(.type == "init") | .sessionId' | head -1)
 RESPONSE=$(echo "$OUTPUT" | jq -r 'select(.type == "result") | .response' | head -1)
@@ -42,7 +42,7 @@ echo "Response: $RESPONSE"
 # Continue the session
 FOLLOW_UP=$(gemini -p "Compare to linear attention" \
   --resume "$SESSION_ID" \
-  --output-format stream-json --approval-mode yolo | \
+  --output-format stream-json --yolo | \
   jq -r 'select(.type == "result") | .response')
 ```
 
@@ -57,7 +57,7 @@ FOLLOW_UP=$(gemini -p "Compare to linear attention" \
 for file in *.py; do
   echo "Processing $file..."
   summary=$(cat "$file" | gemini -p "Summarize this Python module in 2 sentences." \
-    --approval-mode yolo --output-format json | jq -r '.response')
+    --yolo --output-format json | jq -r '.response')
   echo "## $file" >> summaries.md
   echo "$summary" >> summaries.md
   echo "" >> summaries.md
@@ -73,7 +73,7 @@ done
 process_file() {
   local file=$1
   local result=$(cat "$file" | gemini -p "Extract all TODO comments and their context." \
-    --approval-mode yolo --output-format json | jq -r '.response')
+    --yolo --output-format json | jq -r '.response')
   echo "### $file" >> todos.md
   echo "$result" >> todos.md
 }
@@ -94,7 +94,7 @@ find . -name "*.py" | xargs -P 4 -I{} bash -c 'process_file "$@"' _ {}
 gcommit() {
   local message=$(git diff --staged | \
     gemini -p "Write a conventional commit message. Return only the commit message, no commentary." \
-    --approval-mode yolo --output-format json | jq -r '.response')
+    --yolo --output-format json | jq -r '.response')
 
   echo "Generated: $message"
   read -p "Use this message? [y/N] " confirm
@@ -109,7 +109,7 @@ gcommit() {
 ```bash
 gsearch() {
   gemini -p "Search the web: $*. Return a concise answer with sources." \
-    --model flash --approval-mode yolo --output-format json | jq -r '.response'
+    --model flash --yolo --output-format json | jq -r '.response'
 }
 
 # Usage
@@ -123,7 +123,7 @@ greview() {
   local target=${1:-HEAD~1}
   git diff "$target" | gemini \
     -p "Review this diff. List: 1) Bugs, 2) Security issues, 3) Improvements. Be concise." \
-    --approval-mode yolo --output-format json | jq -r '.response'
+    --yolo --output-format json | jq -r '.response'
 }
 ```
 
@@ -140,7 +140,7 @@ Use `GEMINI_SYSTEM_MD` to set a system prompt — store prompts in `.gemini/prom
 
 GEMINI_SYSTEM_MD=.gemini/prompts/research-assistant.md \
   gemini -p "Find papers on diffusion transformers" \
-  --approval-mode yolo --output-format json
+  --yolo --output-format json
 ```
 
 ---
@@ -153,7 +153,7 @@ GEMINI_SYSTEM_MD=.gemini/prompts/research-assistant.md \
   run: |
     PR_BODY=$(git diff origin/main...HEAD | \
       gemini -p "Write a GitHub PR description. Include: summary, changes, testing notes." \
-      --approval-mode yolo --output-format json | jq -r '.response')
+      --yolo --output-format json | jq -r '.response')
     gh pr edit --body "$PR_BODY"
   env:
     GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
@@ -172,7 +172,7 @@ run_gemini() {
   local prompt=$1
   local output exit_code
 
-  output=$(gemini -p "$prompt" --output-format json --approval-mode yolo 2>/tmp/gemini-stderr)
+  output=$(gemini -p "$prompt" --output-format json --yolo 2>/tmp/gemini-stderr)
   exit_code=$?
 
   case $exit_code in

--- a/skills/gemini-cli/references/cli-reference.md
+++ b/skills/gemini-cli/references/cli-reference.md
@@ -50,17 +50,11 @@ Full model IDs can also be passed directly:
 
 ### Approval Mode
 
-| Flag | Values | Default |
-|------|--------|---------|
-| `--approval-mode <mode>` | `default`, `auto_edit`, `yolo` | `default` |
+| Flag | Description |
+|------|-------------|
+| `--yolo`, `-y` | Auto-approves all tool actions — **required for headless** |
 
-| Mode | Behavior |
-|------|---------|
-| `default` | Requires confirmation for all tool actions — **BLOCKS** in headless (no TTY) |
-| `auto_edit` | Auto-approves file edits; prompts for shell/network actions |
-| `yolo` | Auto-approves all actions — **required for headless** |
-
-> ⚠️ Always use `--approval-mode yolo` in headless/automated contexts. Without it, Gemini CLI will block waiting for interactive confirmation that can never arrive.
+> ⚠️ Always use `--yolo` in headless/automated contexts. Without it, Gemini CLI will block waiting for interactive confirmation that can never arrive.
 
 ### Sandbox
 
@@ -68,7 +62,7 @@ Full model IDs can also be passed directly:
 |------|-------|-------------|
 | `--sandbox` | `-s` | Run tool execution in a sandboxed environment |
 
-Use `--sandbox` with `--approval-mode yolo` to auto-approve actions while limiting their blast radius. Recommended default for all headless calls.
+Use `--sandbox` with `--yolo` to auto-approve actions while limiting their blast radius. Recommended default for all headless calls.
 
 ### Session Continuation
 
@@ -124,7 +118,7 @@ gemini \
   --prompt "Search for recent papers on mixture-of-experts architectures" \
   --output-format stream-json \
   --model flash \
-  --approval-mode yolo \
+  --yolo \
   --sandbox \
   --include-directories /tmp/gemini-context-xyz
 ```
@@ -147,13 +141,13 @@ Gemini CLI reads stdin in headless mode, allowing you to pipe file contents or c
 
 ```bash
 # Pipe a git diff for review
-git diff HEAD~1 | gemini -p "Review this diff. Focus on security issues." --approval-mode yolo
+git diff HEAD~1 | gemini -p "Review this diff. Focus on security issues." --yolo
 
 # Pipe a log file
-tail -n 1000 app.log | gemini -p "What's causing these errors?" --approval-mode yolo
+tail -n 1000 app.log | gemini -p "What's causing these errors?" --yolo
 
 # Pipe command output
-kubectl describe pod my-pod | gemini -p "Is this pod healthy? What's wrong?" --approval-mode yolo
+kubectl describe pod my-pod | gemini -p "Is this pod healthy? What's wrong?" --yolo
 ```
 
 ---
@@ -163,7 +157,7 @@ kubectl describe pod my-pod | gemini -p "Is this pod healthy? What's wrong?" --a
 **Recommended:** Use `GEMINI_SYSTEM_MD` to override the system prompt per-call. Store prompts in `.gemini/prompts/`:
 
 ```bash
-GEMINI_SYSTEM_MD=.gemini/prompts/persona.md gemini -p "Review this code" --approval-mode yolo
+GEMINI_SYSTEM_MD=.gemini/prompts/persona.md gemini -p "Review this code" --yolo
 ```
 
 Gemini CLI also reads `GEMINI.md` files from the current working directory (and parent directories) as project context — analogous to Claude Code's `CLAUDE.md`.

--- a/skills/gemini-cli/references/headless.md
+++ b/skills/gemini-cli/references/headless.md
@@ -204,7 +204,7 @@ TypeScript/Node.js example:
 import { spawn } from 'child_process';
 
 async function runGemini(prompt: string): Promise<{ response: string; sessionId: string }> {
-  const proc = spawn('gemini', ['-p', prompt, '--output-format', 'stream-json', '--approval-mode', 'yolo', '--sandbox']);
+  const proc = spawn('gemini', ['-p', prompt, '--output-format', 'stream-json', '--yolo', '--sandbox']);
 
   let sessionId = '';
   let response = '';

--- a/skills/quarto-authoring/SKILL.md
+++ b/skills/quarto-authoring/SKILL.md
@@ -316,7 +316,7 @@ format:
 
 ## Resources
 
-- [Quarto Documentation](https://quarto.org/docs/)
+- [Quarto Documentation](https://quarto.org/)
 - [Quarto Guide](https://quarto.org/docs/guide/)
 - [Quarto Extensions](https://quarto.org/docs/extensions/)
 - [Community Extensions List](https://m.canouil.dev/quarto-extensions/)

--- a/skills/quarto-authoring/SKILL.md
+++ b/skills/quarto-authoring/SKILL.md
@@ -316,7 +316,10 @@ format:
 
 ## Resources
 
+<!-- lychee-ignore -->
 - [Quarto Documentation](https://quarto.org/)
+<!-- lychee-ignore -->
 - [Quarto Guide](https://quarto.org/docs/guide/)
+<!-- lychee-ignore -->
 - [Quarto Extensions](https://quarto.org/docs/extensions/)
 - [Community Extensions List](https://m.canouil.dev/quarto-extensions/)

--- a/skills/quarto-authoring/references/conversion-rmarkdown.md
+++ b/skills/quarto-authoring/references/conversion-rmarkdown.md
@@ -333,5 +333,5 @@ Verify `#|` syntax and dashes (not dots).
 ## Resources
 
 - [Quarto for R Markdown Users](https://quarto.org/docs/faq/rmarkdown.html)
-- [Quarto vs R Markdown](https://quarto.org/docs/faq/rmarkdown.html#quarto-vs.-r-markdown)
+- [Quarto vs R Markdown](https://quarto.org/docs/faq/rmarkdown.html#quarto-sounds-similar-to-r-markdown.-what-is-the-difference-and-why-create-a-new-project)
 

--- a/skills/quarto-authoring/references/extensions.md
+++ b/skills/quarto-authoring/references/extensions.md
@@ -15,6 +15,7 @@ Quarto extensions add custom functionality including shortcodes, filters, format
 
 ### Official Repository
 
+<!-- lychee-ignore -->
 - [Quarto Extensions](https://quarto.org/docs/extensions/)
 - Browse by category: filters, shortcodes, formats, etc.
 
@@ -312,7 +313,9 @@ If extensions conflict, try:
 
 ## Resources
 
+<!-- lychee-ignore -->
 - [Quarto Extensions Guide](https://quarto.org/docs/extensions/)
+<!-- lychee-ignore -->
 - [Creating Extensions](https://quarto.org/docs/extensions/creating.html)
 - [Community Extensions](https://m.canouil.dev/quarto-extensions/)
 - [Extensions JSON API](https://m.canouil.dev/quarto-extensions/extensions.json)

--- a/skills/shiny-bslib/references/navigation.md
+++ b/skills/shiny-bslib/references/navigation.md
@@ -36,10 +36,10 @@ navset_*(
 
 All `navset_*()` functions accept any number of `nav_panel()` items as their primary arguments. Choose the variant based on visual style and layout needs:
 
-- **`navset_underline()`** — Modern underline-style; recommended for most use cases. Use for clean, modern interfaces with 2–5 items.
-- **`navset_tab()`** — Traditional filled-background tabs. Use when users expect classic Bootstrap tab styling or need stronger visual separation.
-- **`navset_pill()`** — Horizontal rounded pill buttons. Use when you want a button-like appearance for navigation items.
-- **`navset_pill_list()`** — Vertical sidebar-style pill list. Use when you have many items (5+) or when vertical layout fits the design.
+- <a id="navset_underline"></a>**`navset_underline()`** — Modern underline-style; recommended for most use cases. Use for clean, modern interfaces with 2–5 items.
+- <a id="navset_tab"></a>**`navset_tab()`** — Traditional filled-background tabs. Use when users expect classic Bootstrap tab styling or need stronger visual separation.
+- <a id="navset_pill"></a>**`navset_pill()`** — Horizontal rounded pill buttons. Use when you want a button-like appearance for navigation items.
+- <a id="navset_pill_list"></a>**`navset_pill_list()`** — Vertical sidebar-style pill list. Use when you have many items (5+) or when vertical layout fits the design.
 
 ### navset_bar()
 


### PR DESCRIPTION
Fixes issue #40 by replacing the invalid `--approval-mode yolo` flag with `--yolo` in the `gemini-cli` skill documentation. Included changie fragment as required.

---
*PR created automatically by Jules for task [718488437700367268](https://jules.google.com/task/718488437700367268) started by @rudolfjs*