### PR TITLE
chore: add changelog fragment for rst references

### DIFF
--- a/.changes/unreleased/Changed-20260410-230222.yaml
+++ b/.changes/unreleased/Changed-20260410-230222.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Add rst references and speckit integrations
+time: 2026-04-10T23:02:22.517121062Z


### PR DESCRIPTION
Adds a missing changelog fragment to fix the failing "Changelog Check" CI workflow on this branch.

---
*PR created automatically by Jules for task [4296858202155004531](https://jules.google.com/task/4296858202155004531) started by @rudolfjs*