### PR TITLE
Add missing changie fragment for v0.3.0 batch release

### DIFF
--- a/.changes/unreleased/Added-release-0.3.0.yaml
+++ b/.changes/unreleased/Added-release-0.3.0.yaml
@@ -1,0 +1,2 @@
+kind: Added
+body: Batch changelog for v0.3.0 release


### PR DESCRIPTION
Fixes CI Changelog Check failure by providing the missing changie fragment for the batch release process in v0.3.0.

---
*PR created automatically by Jules for task [2103442882184914693](https://jules.google.com/task/2103442882184914693) started by @rudolfjs*