### PR TITLE
fix: correct frontmatter in cc-agent-teams skill to pass validation

### DIFF
--- a/.changes/unreleased/Fixed-cc-agent-teams-validation.yaml
+++ b/.changes/unreleased/Fixed-cc-agent-teams-validation.yaml
@@ -1,0 +1,2 @@
+kind: Fixed
+body: Fix validation of cc-agent-teams skill by moving argument-hint and user-invocable into metadata

--- a/skills/cc-agent-teams/SKILL.md
+++ b/skills/cc-agent-teams/SKILL.md
@@ -9,11 +9,11 @@ description: >-
   SendMessage, teammate mode, team lead, agent coordination, parallel sessions,
   or 'can we parallelize this with agents?'. Helps with planning parallel
   execution strategies and structuring team-based work.
-argument-hint: "Describe the work to parallelize (e.g., 'review PR #42 for security and performance')"
 compatibility: >-
   Requires Claude Code v2.1.32+. Split-pane mode requires tmux or iTerm2.
-user-invocable: true
 metadata:
+  argument-hint: "Describe the work to parallelize (e.g., 'review PR #42 for security and performance')"
+  user-invocable: true
   repo: https://github.com/nq-rdl/agent-skills
 ---
 


### PR DESCRIPTION
This PR fixes the failing "Validate Skills" CI job on the `release/0.3.0` branch.

**Diagnosis:**
The `cc-agent-teams` skill contained custom properties (`argument-hint` and `user-invocable`) directly at the root of its frontmatter. This violated the strict schema rules in `src/skills/ref/validator.py`, which only allow specific predefined fields (such as `name`, `description`, `metadata`, etc.) at the top level.

**Fix:**
* Nested `argument-hint` and `user-invocable` underneath the `metadata` dictionary block in `skills/cc-agent-teams/SKILL.md` as expected by the specification for arbitrary key-value mappings.
* Added a `Fixed` changelog fragment to `.changes/unreleased/` to unblock the required "Changelog Check" workflow.

Validated using `pixi run validate-skills` and verified all tests pass (`pixi run test`).

---
*PR created automatically by Jules for task [13876186684959414448](https://jules.google.com/task/13876186684959414448) started by @rudolfjs*