### PR TITLE
fix: correct frontmatter in cc-agent-teams skill to pass CI

### DIFF
--- a/.changes/unreleased/Fixed-20260416-frontmatter.yaml
+++ b/.changes/unreleased/Fixed-20260416-frontmatter.yaml
@@ -1,0 +1,2 @@
+kind: Fixed
+body: Move `argument-hint` and `user-invocable` to the `metadata` block in `cc-agent-teams` skill to fix CI frontmatter validation failure.

--- a/skills/cc-agent-teams/SKILL.md
+++ b/skills/cc-agent-teams/SKILL.md
@@ -9,11 +9,11 @@ description: >-
   SendMessage, teammate mode, team lead, agent coordination, parallel sessions,
   or 'can we parallelize this with agents?'. Helps with planning parallel
   execution strategies and structuring team-based work.
-argument-hint: "Describe the work to parallelize (e.g., 'review PR #42 for security and performance')"
 compatibility: >-
   Requires Claude Code v2.1.32+. Split-pane mode requires tmux or iTerm2.
-user-invocable: true
 metadata:
+  argument-hint: "Describe the work to parallelize (e.g., 'review PR #42 for security and performance')"
+  user-invocable: true
   repo: https://github.com/nq-rdl/agent-skills
 ---
 


### PR DESCRIPTION
Fixes the "Validate Skills" and "Changelog Check" CI failures on the `release/0.3.0` branch.

- Corrected the `skills/cc-agent-teams/SKILL.md` frontmatter by moving `argument-hint` and `user-invocable` into the `metadata` block.
- Added a `.changes/unreleased/Fixed-20260416-frontmatter.yaml` changelog fragment.

---
*PR created automatically by Jules for task [11070192381134734338](https://jules.google.com/task/11070192381134734338) started by @rudolfjs*