### PR TITLE
chore: add missing changelog fragment for rst box alignment fix

### DIFF
--- a/.changes/unreleased/Fixed-20260417-rst-box-alignment.yaml
+++ b/.changes/unreleased/Fixed-20260417-rst-box-alignment.yaml
@@ -1,2 +1,2 @@
 kind: Fixed
-body: align misaligned ASCII-art boxes in rst references
+body: Align misaligned ASCII-art boxes in RST references

--- a/.changes/unreleased/Fixed-20260417-rst-box-alignment.yaml
+++ b/.changes/unreleased/Fixed-20260417-rst-box-alignment.yaml
@@ -1,0 +1,2 @@
+kind: Fixed
+body: align misaligned ASCII-art boxes in rst references


### PR DESCRIPTION
Adds a missing changie fragment to satisfy the CI `changelog-check` workflow, describing the ASCII-art box alignment fixes in `.rst` reference files.

---
*PR created automatically by Jules for task [3750153629444685625](https://jules.google.com/task/3750153629444685625) started by @rudolfjs*