### PR TITLE
fix(pi-cli): replace stale session-create required-fields test

### DIFF
--- a/.changes/unreleased/Fixed-20260419-120000-pi-cli-session-create-defaults-test.yaml
+++ b/.changes/unreleased/Fixed-20260419-120000-pi-cli-session-create-defaults-test.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: Replace stale TestRunSessionCreateMissingRequiredFields with TestRunSessionCreateDefaultsAccepted — provider/model are optional and fall through to PI_DEFAULT_PROVIDER / PI_DEFAULT_MODEL on the server, so the CLI must not reject empty values
+time: 2026-04-19T12:00:00Z

--- a/skills/pi-rpc/scripts/cmd/pi-cli/session_test.go
+++ b/skills/pi-rpc/scripts/cmd/pi-cli/session_test.go
@@ -72,15 +72,20 @@ func TestRunSessionCreate(t *testing.T) {
 	}
 }
 
-func TestRunSessionCreateMissingRequiredFields(t *testing.T) {
-	// The cobra command enforces --provider and --model as required flags,
-	// but we also guard in the RunE function.
-	cmd := newSessionCreateCmd(ptrString(""))
-	cmd.SetArgs([]string{}) // no flags
+func TestRunSessionCreateDefaultsAccepted(t *testing.T) {
+	// Provider and model are optional at the CLI — when empty they fall
+	// through to PI_DEFAULT_PROVIDER / PI_DEFAULT_MODEL on the server. Verify
+	// that an empty provider/model does not trigger a client-side error.
+	srv := newTestServer(t, map[string]any{
+		"/pirpc.v1.SessionService/Create": map[string]string{
+			"sessionId": "defaults-abc",
+			"state":     "SESSION_STATE_IDLE",
+		},
+	})
+	defer srv.Close()
 
-	err := cmd.Execute()
-	if err == nil {
-		t.Error("expected error when provider/model not set")
+	if err := runSessionCreate(context.Background(), srv.URL, "", "", "/tmp", "", 0); err != nil {
+		t.Errorf("runSessionCreate with empty provider/model failed: %v", err)
 	}
 }
 
@@ -258,6 +263,3 @@ func TestSessionSubcommands(t *testing.T) {
 		}
 	}
 }
-
-// ptrString is a helper for passing flag pointers to subcommand constructors in tests.
-func ptrString(s string) *string { return &s }


### PR DESCRIPTION
## Summary

Closes #70.

`TestRunSessionCreateMissingRequiredFields` in `skills/pi-rpc/scripts/cmd/pi-cli/session_test.go` asserted that `pi-cli session create` errors when `--provider` or `--model` are omitted. Those flags were later made optional — empty values fall through to `PI_DEFAULT_PROVIDER` / `PI_DEFAULT_MODEL` on the server — but the test was never updated.

On `main`, the failure only surfaced when a pi-server was running locally:

- **No pi-server** → connection error → `err != nil` → test passed *incidentally* (wrong reason)
- **pi-server running locally** → server returns a valid `sessionId` → `err == nil` → test fails

That incidental-pass masking is exactly the category of silent failure that the pre-push hook is meant to catch, and pushing past it with `--no-verify` (as noted in #70) erodes that guarantee.

## Change

Replace the stale test with `TestRunSessionCreateDefaultsAccepted`, which uses a mock `httptest.Server` and explicitly verifies that an empty `provider`/`model` does **not** trigger a client-side error — matching documented behavior.

Drop the now-unused `ptrString` helper (it only existed for the old test's cobra-flag plumbing).

## Reproduce the original failure (before this PR)

```bash
cd skills/pi-rpc/scripts
PI_SERVER_URL=http://localhost:8080 go test ./cmd/pi-cli/... \
  -run TestRunSessionCreateMissingRequiredFields -v
# --- FAIL: TestRunSessionCreateMissingRequiredFields
#     session_test.go:83: expected error when provider/model not set
```

## Verify the fix

```bash
go test -race -count=1 ./...
# ok  skills/pi-rpc/scripts/cmd/pi-cli  1.030s
# ok  skills/pi-rpc/scripts/handler     3.171s
# ok  skills/pi-rpc/scripts/internal/config  1.016s
```

`lefthook run pre-push` passes (the same hook that originally flagged the bug).

## Scope

Minimal — one test rewrite in one file, plus a changie fragment. No runtime code changes.

## Not in this PR

- The pre-existing `gofmt` misalignment in `session.go:111–117` (unrelated to #70; belongs to the formatting pass in PR #69).
- PR #68 mentions the same test fix as a side note under a different name (`TestRunSessionCreateDefaultsAccepted`) — this PR delivers that rename as a focused, reviewable unit that explicitly closes #70.
