### PR TITLE
test(pi-cli): lock in session create defaults contract (#70)

### DIFF
--- a/.changes/unreleased/Fixed-20260419-061142-pi-cli-session-create-defaults-test.yaml
+++ b/.changes/unreleased/Fixed-20260419-061142-pi-cli-session-create-defaults-test.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: pi-cli `session create` test coverage — add positive-case `TestRunSessionCreateDefaultsAccepted` asserting empty provider/model are forwarded verbatim so the server can apply PI_DEFAULT_PROVIDER / PI_DEFAULT_MODEL (closes #70)
+time: 2026-04-19T06:11:42Z

--- a/skills/pi-rpc/scripts/cmd/pi-cli/session_test.go
+++ b/skills/pi-rpc/scripts/cmd/pi-cli/session_test.go
@@ -84,6 +84,37 @@ func TestRunSessionCreateUnreachableServer(t *testing.T) {
 	}
 }
 
+func TestRunSessionCreateDefaultsAccepted(t *testing.T) {
+	// Issue #70: empty provider/model must be forwarded verbatim so the server
+	// can apply PI_DEFAULT_PROVIDER / PI_DEFAULT_MODEL. The CLI must not
+	// reject or mutate empty values.
+	var receivedProvider, receivedModel string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("decode request body: %v", err)
+		}
+		receivedProvider, _ = req["provider"].(string)
+		receivedModel, _ = req["model"].(string)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"sessionId": "defaults-abc",
+			"state":     "SESSION_STATE_IDLE",
+		})
+	}))
+	defer srv.Close()
+
+	if err := runSessionCreate(context.Background(), srv.URL, "", "", "/tmp", "", 0); err != nil {
+		t.Fatalf("runSessionCreate with empty provider/model failed: %v", err)
+	}
+	if receivedProvider != "" {
+		t.Errorf("provider forwarded to server = %q, want empty string", receivedProvider)
+	}
+	if receivedModel != "" {
+		t.Errorf("model forwarded to server = %q, want empty string", receivedModel)
+	}
+}
+
 func TestRunSessionList(t *testing.T) {
 	srv := newTestServer(t, map[string]any{
 		"/pirpc.v1.SessionService/List": map[string]any{

--- a/skills/pi-rpc/scripts/cmd/pi-cli/session_test.go
+++ b/skills/pi-rpc/scripts/cmd/pi-cli/session_test.go
@@ -89,10 +89,13 @@ func TestRunSessionCreateDefaultsAccepted(t *testing.T) {
 	// can apply PI_DEFAULT_PROVIDER / PI_DEFAULT_MODEL. The CLI must not
 	// reject or mutate empty values.
 	var receivedProvider, receivedModel string
+	done := make(chan struct{})
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer close(done)
 		var req map[string]any
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			t.Errorf("decode request body: %v", err)
+			return
 		}
 		receivedProvider, _ = req["provider"].(string)
 		receivedModel, _ = req["model"].(string)
@@ -104,9 +107,10 @@ func TestRunSessionCreateDefaultsAccepted(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	if err := runSessionCreate(context.Background(), srv.URL, "", "", "/tmp", "", 0); err != nil {
+	if err := runSessionCreate(context.Background(), srv.URL, "", "", t.TempDir(), "", 0); err != nil {
 		t.Fatalf("runSessionCreate with empty provider/model failed: %v", err)
 	}
+	<-done
 	if receivedProvider != "" {
 		t.Errorf("provider forwarded to server = %q, want empty string", receivedProvider)
 	}


### PR DESCRIPTION
## Closes #70 — stacked on #69

This PR adds the positive test counterpart to `TestRunSessionCreateUnreachableServer` introduced in #69.

### What it does
- **Adds `TestRunSessionCreateDefaultsAccepted`** in `skills/pi-rpc/scripts/cmd/pi-cli/session_test.go`
- Spins up an `httptest` server that **decodes the Create request body** and asserts the CLI forwards empty `provider` / `model` **verbatim**, so the server can apply `PI_DEFAULT_PROVIDER` / `PI_DEFAULT_MODEL`.
- Adds a changie fragment.

### Why two tests?
After #69 the CLI's Create behavior is pinned from both sides:

| Scenario | Test | Outcome |
|---|---|---|
| Server unreachable, empty flags | `TestRunSessionCreateUnreachableServer` | RPC error surfaces to user |
| Server reachable, empty flags | `TestRunSessionCreateDefaultsAccepted` (new) | 200 OK + empty strings forwarded verbatim |

Together these prevent the #70 regression mode where a test passed *incidentally* (`err != nil` from a connection failure because no `pi-server` was running locally).

### Stacking notes
- Base: `fix/pi-rpc-cross-compile` (PR #69)
- Head: `bug/testrunmissing-pi-rpc`
- If #69 rebases, this branch will need a rebase too; merge-order is #69 → this PR.

### Verification
```
go test -race -count=1 ./skills/pi-rpc/scripts/cmd/pi-cli/...
ok  	github.com/nq-rdl/agent-skills/skills/pi-rpc/scripts/cmd/pi-cli	1.032s
```

### Hook bypass disclosure
Push used `--no-verify` (with user authorization) to route around a pre-existing flaky `go-test-jules` test (`TestOrchestratorWorkflowIntegration`: `fatal: a branch named 'main' already exists`). That flake is unrelated to this change and reproduces only under lefthook's parallel runner; solo runs are green.

### Review provenance
Plan was dual-reviewed (`gemini-3.1-pro-preview` + `pi --provider openai-codex --model gpt-5.4:xhigh`). Both converged on: keep #69's negative test, add the positive test with **request-body assertion** on empty provider/model forwarding (what this PR does).