### PR TITLE
fix(release): write release notes to RUNNER_TEMP to unblock v0.4.0

### DIFF
--- a/.changes/unreleased/Fixed-20260419-release-goreleaser-dirty-state.yaml
+++ b/.changes/unreleased/Fixed-20260419-release-goreleaser-dirty-state.yaml
@@ -1,0 +1,2 @@
+kind: Fixed
+body: Write release notes to $RUNNER_TEMP so goreleaser's dirty-state check does not fail on the untracked release-notes.md file

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,7 @@ jobs:
           TAG: ${{ github.ref_name }}
         run: |
           version="${TAG#v}"
-          cp ".changes/${version}.md" release-notes.md
+          cp ".changes/${version}.md" "${RUNNER_TEMP}/release-notes.md"
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -113,7 +113,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           version: latest
-          args: release --clean --release-notes release-notes.md
+          args: release --clean --release-notes ${{ runner.temp }}/release-notes.md
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 


### PR DESCRIPTION
## Problem

The v0.4.0 release workflow failed at the goreleaser step ([run 24629648688](https://github.com/nq-rdl/agent-skills/actions/runs/24629648688)):

```
  ⨯ release failed after 0s
    error=
    │ git is in a dirty state
    │ Please check in your pipeline what can be changing the following files:
    │ ?? release-notes.md
    │ Learn more at https://goreleaser.com/errors/dirty
```

The `Prepare release notes` step copies `.changes/${version}.md` to `release-notes.md` inside the workdir. That file is untracked, which trips goreleaser's safety check that requires a clean working tree.

The tag `v0.4.0` and the `chore: update changelog for v0.4.0` commit on `main` were already created before goreleaser ran, so those are fine — only the GitHub release itself is missing.

## Fix

Write `release-notes.md` to `$RUNNER_TEMP` (outside the working tree) and pass the absolute path to goreleaser via `${{ runner.temp }}`. This keeps the workdir clean for goreleaser's dirty-state check without polluting `.gitignore` with a transient CI artifact.

## Re-releasing v0.4.0 after merge

The changelog has already been batched into `.changes/0.4.0.md` on `main`, so the release workflow's `needs_batch=false` branch will skip the batch/commit/force-push steps on the re-run.

Suggested steps once this PR is merged:

```bash
# delete the (broken) tag locally and on the remote
git tag -d v0.4.0
git push origin :refs/tags/v0.4.0

# retag main (which now includes this fix) and push
git fetch origin main
git checkout main
git pull --ff-only
git tag v0.4.0
git push origin v0.4.0
```

## Testing

Can't exercise the goreleaser dirty-state check locally in CI, but the logic is straightforward: `$RUNNER_TEMP` is outside the checkout, so git's view of the workdir is unchanged. The `needs_batch=false` path has been used before (see [PR #62 / 3d56456](https://github.com/nq-rdl/agent-skills/commit/3d56456)) and is what will run on the retry.