### PR TITLE
fix(release): fail loudly when both batched file and unreleased fragments exist

### DIFF
--- a/.changes/unreleased/Fixed-20260419-release-goreleaser-dirty-state.yaml
+++ b/.changes/unreleased/Fixed-20260419-release-goreleaser-dirty-state.yaml
@@ -1,2 +1,0 @@
-kind: Fixed
-body: Write release notes to $RUNNER_TEMP so goreleaser's dirty-state check does not fail on the untracked release-notes.md file

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,15 @@ jobs:
             exit 1
           fi
 
+          if [ -n "$has_unreleased" ] && [ -n "$has_batched" ]; then
+            echo "::error::Both unreleased fragments and a pre-batched .changes/${version}.md exist. Refusing to re-batch and overwrite the existing file."
+            echo "::error::This typically happens on a release retry when a fix PR added a new changie fragment."
+            echo "::error::Resolve by picking one:"
+            echo "::error::  (a) If the fragments belong in ${TAG}: merge their content into .changes/${version}.md and CHANGELOG.md, then delete the fragment files."
+            echo "::error::  (b) If the fragments should not ship here (e.g. internal CI plumbing): delete the fragment files. For future retry PRs, apply the 'skip-changelog' label so changelog-check does not require a fragment."
+            exit 1
+          fi
+
           if [ -n "$has_unreleased" ]; then
             echo "needs_batch=true" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## Problem

After PR #73 merged, retagging v0.4.0 triggered the release workflow which failed at `Batch and merge changelog` ([run 24629980953](https://github.com/nq-rdl/agent-skills/actions/runs/24629980953)):

```
Error: version already exists: .changes/0.4.0.md
```

**Why:** PR #73 had to add a changie fragment to pass `changelog-check`. After merge, `.changes/unreleased/` contained that new fragment, and `.changes/0.4.0.md` already existed from the first (pre-goreleaser-fix) release attempt. The current `Detect changelog state` step only distinguishes three cases — unreleased-only, batched-only, neither — and silently runs `changie batch` whenever unreleased fragments exist, even when the batched file is already there.

This is a gap that will bite any release retry that involves a fix PR adding a new fragment.

## Fix

Two changes:

1. **Harden `Detect changelog state`** — error out explicitly with operator guidance when both a batched version file and unreleased fragments exist. The message tells them to either (a) merge the fragments into `.changes/X.Y.Z.md` if they belong in this release, or (b) delete the fragments if they do not (and use the `skip-changelog` label on future retry PRs to avoid needing a fragment at all).

2. **Remove the stray fragment from PR #73** — the `release-notes.md → $RUNNER_TEMP` fix is internal CI plumbing and doesn't need a user-facing changelog entry. Deleting it so `.changes/unreleased/` is empty for the retag.

## This PR is skip-changelog by design

This PR's own change (workflow hardening) is also internal CI plumbing — not user-visible — so it carries the `skip-changelog` label to keep `.changes/unreleased/` empty for the retag. That is precisely the pattern the hardened error message recommends.

## Re-releasing v0.4.0 after merge

```bash
# delete the broken tag locally + remotely
git tag -d v0.4.0
git push origin :refs/tags/v0.4.0

# fast-forward main
git checkout main && git pull --ff-only

# retag and push
git tag v0.4.0
git push origin v0.4.0
```

Post-merge, `.changes/unreleased/` is empty and `.changes/0.4.0.md` exists → the workflow takes `needs_batch=false` → skips batch/commit/force-push → writes `release-notes.md` to `$RUNNER_TEMP` (PR #73) → goreleaser runs with a clean worktree.

## Testing

The hardened logic is a pure addition to a shell conditional — the existing `needs_batch=true` and `needs_batch=false` paths are unchanged. The new `both exist` branch is what fires on the current v0.4.0 retry state if you don't delete the fragment, which is what this PR itself removes.