### PR TITLE
fix(jules): remove redundant toolchain directive from go.mod

### DIFF
--- a/skills/jules/scripts/go.mod
+++ b/skills/jules/scripts/go.mod
@@ -1,5 +1,3 @@
 module github.com/nq-rdl/agent-skills/skills/jules/scripts
 
 go 1.25.0
-
-toolchain go1.25.0


### PR DESCRIPTION
## Problem

The v0.4.0 release got past the changelog/dirty-state failures (PR #73 and #74) but failed at the goreleaser build step ([run 24630128599](https://github.com/nq-rdl/agent-skills/actions/runs/24630128599)):

```
⨯ release failed after 54s
  error=
  │ build failed: exit status 1: go: updates to go.mod needed; to update it:
  │   go mod tidy
  target=linux_amd64_v1
```

## Root cause

`skills/jules/scripts/go.mod` carried both:

```
go 1.25.0

toolchain go1.25.0
```

When the `toolchain` directive matches the `go` directive, Go's module tooling treats it as redundant and `go build` with `GOWORK=off` (which goreleaser uses — see `.goreleaser.yaml` per-build `env: [GOWORK=off]`) fails the default `-mod=readonly` check.

The other two Go modules in the workspace (`skills/pi-rpc/scripts`, `tools/asctl`) do not have this pattern, so only jules needed the change.

## Fix

`go mod tidy` (with `GOWORK=off`) inside `skills/jules/scripts/` removes the redundant `toolchain go1.25.0` line. The diff is two lines deleted.

## Why CI didn't catch this

There is no workflow running `go build ./...` against the jules module with `GOWORK=off`. `pi-rpc-go.yml` covers pi-rpc; jules has no equivalent build job. Worth adding in a follow-up, but out of scope for unblocking v0.4.0.

## Re-releasing v0.4.0 after merge

```bash
git tag -d v0.4.0
git push origin :refs/tags/v0.4.0
git checkout main && git pull --ff-only
git tag v0.4.0
git push origin v0.4.0
```

`.changes/unreleased/` stays empty (skip-changelog), `.changes/0.4.0.md` is still the authoritative batched file → workflow takes the `needs_batch=false` path → goreleaser runs on the fixed go.mod. All three previously-broken links in the chain should now hold.