### PR TITLE
fix(release): install syft before goreleaser so SBOM step can catalog archives

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,9 @@ jobs:
           go-version-file: .go-version
           cache: true
 
+      - name: Install syft for SBOM generation
+        uses: anchore/sbom-action/download-syft@v0
+
       - name: Run goreleaser
         uses: goreleaser/goreleaser-action@v6
         with:


### PR DESCRIPTION
## Problem

v0.4.0 release ([run 24630217662](https://github.com/nq-rdl/agent-skills/actions/runs/24630217662)) got past changelog + go.mod issues, built all binaries, archived them, and then failed at the SBOM step:

```
⨯ release failed after 1m13s
  error=exec: "syft": executable file not found in $PATH
  message=could not catalog artifact
  cmd=syft
  artifact=dist/pi-server-0.4.0-darwin-arm64.tar.gz
```

## Root cause

`.goreleaser.yaml` has an `sboms:` block:

```yaml
sboms:
  - artifacts: archive
    args: ["$artifact", "--output", "cyclonedx-json=$document"]
    documents:
      - "{{ .ArtifactName }}.sbom.json"
```

goreleaser shells out to `syft` for each archive to produce a CycloneDX SBOM. The `release.yml` workflow never installs syft, so it isn't on PATH when goreleaser invokes it.

## Fix

Add `anchore/sbom-action/download-syft@v0` between `Set up Go` and `Run goreleaser`. This is the Anchore-maintained action whose sole purpose is to drop the `syft` binary into the runner's PATH — no other side effects.

## Scope

Single workflow file, 3 lines added. Uses the skip-changelog label since this is internal CI plumbing.

## Re-releasing v0.4.0 after merge

```bash
git tag -d v0.4.0
git push origin :refs/tags/v0.4.0
git checkout main && git pull --ff-only
git tag v0.4.0
git push origin v0.4.0
```

All prior stages (changelog state detection, release-notes path, jules go.mod tidy) are now solid. This unblocks the last remaining goreleaser step.