### PR TITLE
feat: bitwarden personal PM skill for .env & dev secrets management

### DIFF
--- a/.changes/unreleased/Added-20260420-102010.yaml
+++ b/.changes/unreleased/Added-20260420-102010.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Add bitwarden skill for managing .env files and development secrets using the Bitwarden personal Password Manager CLI (bw)
+time: 2026-04-20T10:20:10.43062568+10:00

--- a/skills/bitwarden/SKILL.md
+++ b/skills/bitwarden/SKILL.md
@@ -1,0 +1,261 @@
+---
+name: bitwarden
+license: MIT
+description: >-
+  Manage .env files and development secrets using the Bitwarden personal
+  Password Manager CLI (bw). Use when the user asks to store, retrieve, or
+  inject secrets / API keys / .env variables from Bitwarden. This skill covers
+  the PERSONAL password manager only — NOT Bitwarden Secrets Manager. Trigger
+  on: "bitwarden .env", "bw CLI secrets", "load API keys from bitwarden",
+  "store credentials in bitwarden", "inject env vars from bitwarden".
+metadata:
+  repo: https://github.com/nq-rdl/agent-skills
+---
+
+# Bitwarden Personal PM — .env & Dev Secrets
+
+Use the Bitwarden **personal** Password Manager CLI (`bw`) to store and load
+development secrets without ever touching a plaintext `.env` file on disk.
+
+> **CRITICAL DISTINCTION**
+> This skill uses the **personal Password Manager** — the `bw` CLI.
+> It does **NOT** use Bitwarden Secrets Manager (`bws`).
+> See [Password Manager overview](https://bitwarden.com/help/password-manager-overview/) vs
+> [Secrets Manager overview](https://bitwarden.com/help/secrets-manager-overview/).
+
+---
+
+## Why Bitwarden for .env?
+
+| Problem | Solution |
+|---------|----------|
+| Plaintext `.env` files leak into git or logs | Secrets live only in encrypted vault |
+| Sharing secrets across machines is risky | Vault syncs automatically — no copying |
+| Secrets stay in memory all session | On-demand loading — gone when terminal closes |
+| Hard to rotate or audit | One vault item to update, all scripts get fresh value |
+
+---
+
+## Quick-Start: Store & Load in 5 Minutes
+
+### 1. Install & Authenticate
+
+```bash
+# Install (choose one)
+npm install -g @bitwarden/cli    # npm
+brew install bitwarden-cli       # macOS Homebrew
+snap install bw                  # Linux Snap
+
+# Log in once (interactive — stores credentials in system keychain)
+bw login
+
+# Unlock vault for the session and capture the session key
+export BW_SESSION="$(bw unlock --raw)"
+```
+
+### 2. Store a Block of .env Variables
+
+Best pattern: store an entire `.env` block as a **Secure Note** in the vault.
+
+```bash
+# Store from an existing .env file
+bw get template item | jq \
+  --rawfile notes .env \
+  --arg name "myproject-dev" \
+  '.type = 2 | .secureNote.type = 0 | .notes = $notes | .name = $name' \
+  | bw encode | bw create item
+```
+
+Or store a single credential on a **Login item**'s custom fields:
+
+```bash
+bw get template item | jq \
+  --arg name "GITHUB_TOKEN" \
+  --arg secret "ghp_xxxx" \
+  '.type = 1 | .name = $name | .fields = [{"name":"value","value":$secret,"type":1}]' \
+  | bw encode | bw create item
+```
+
+### 3. Load Secrets into Current Shell
+
+```bash
+# Load entire .env block from a Secure Note
+eval "$(bw get notes "myproject-dev")"
+
+# Load a single custom field value
+export GITHUB_TOKEN="$(bw get item "GITHUB_TOKEN" | jq -r '.fields[] | select(.name=="value") | .value')"
+
+# Load using item ID (faster — no search ambiguity)
+export GITHUB_TOKEN="$(bw get notes abc1234-xxxx-xxxx-xxxx-xxxxxxxxxxxx)"
+```
+
+---
+
+## Recommended Vault Naming Convention
+
+Use a consistent pattern so `bw list items --search` is predictable:
+
+```
+<project>-<env>          # e.g.  myapp-dev, myapp-staging, myapp-prod
+<service>-credentials    # e.g.  aws-credentials, github-credentials
+```
+
+Example vault layout:
+
+```
+myapp-dev          (Secure Note)  — full .env block for local dev
+myapp-staging      (Secure Note)  — staging .env block
+aws-credentials    (Login)        — AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY as custom fields
+github-credentials (Login)        — GITHUB_TOKEN as custom field
+```
+
+---
+
+## Shell Functions Reference
+
+Add these to `~/.zshrc` or `~/.bashrc`. See [references/shell-functions.rst](references/shell-functions.rst) for the full annotated set.
+
+```bash
+# Unlock vault if no active session
+bwss() {
+  if [[ -z "$BW_SESSION" ]]; then
+    export BW_SESSION="$(bw unlock --raw)"
+  fi
+}
+
+# Load a Secure Note's contents as env vars into current shell
+# Usage: bwe "myapp-dev"
+bwe() {
+  bwss
+  eval "$(bw get notes "$1" --session "$BW_SESSION")"
+}
+
+# Create a Secure Note from current .env file
+# Usage: bwc "myapp-dev"    (reads .env in current dir)
+bwc() {
+  bwss
+  bw get template item \
+    | jq --rawfile notes "${2:-.env}" \
+         --arg name "$1" \
+         '.type = 2 | .secureNote.type = 0 | .notes = $notes | .name = $name' \
+    | bw encode | bw create item --session "$BW_SESSION"
+}
+
+# Update an existing vault item's notes from current .env file
+# Usage: bwu "myapp-dev"
+bwu() {
+  bwss
+  local id
+  id="$(bw get item "$1" --session "$BW_SESSION" | jq -r '.id')"
+  bw get item "$id" --session "$BW_SESSION" \
+    | jq --rawfile notes "${2:-.env}" '.notes = $notes' \
+    | bw encode | bw edit item "$id" --session "$BW_SESSION"
+}
+
+# List all vault item names (filterable)
+# Usage: bwl [filter]
+bwl() {
+  bwss
+  bw list items --search "${1:-}" --session "$BW_SESSION" \
+    | jq -r '.[].name' | sort
+}
+
+# Delete a vault item by name
+# Usage: bwdd "myapp-dev"
+bwdd() {
+  bwss
+  local id
+  id="$(bw get item "$1" --session "$BW_SESSION" | jq -r '.id')"
+  bw delete item "$id" --session "$BW_SESSION"
+}
+```
+
+---
+
+## Security Rules
+
+1. **Never export `BW_SESSION` to disk.** It decrypts the entire vault. It lives only in the current shell's memory.
+2. **Use item IDs in production scripts** — `bw get notes <UUID>` — not names. Names can have duplicates; the CLI errors on ambiguity.
+3. **Store `.env` blocks with `export` prefix** so `eval "$(bw get notes ...)"` populates the current shell.
+4. **Avoid `bw unlock` in cron/CI.** Use `--apikey` with `BW_CLIENTID` / `BW_CLIENTSECRET` and `bw unlock --passwordenv`.
+5. **Sync before reading stale data**: `bw sync` to pull latest from server.
+6. **Do not commit `.env` files** — the whole point. Use `.gitignore`.
+7. **Secrets Manager is NOT this.** If someone suggests `bws` commands, that is a different product.
+
+---
+
+## Common Patterns
+
+### Pattern 1: On-Demand Loading (Recommended)
+
+Load secrets into the current terminal only when needed. They disappear when the terminal closes.
+
+```bash
+# In .zshrc — define but don't auto-run
+autoload -Uz load_myapp_dev
+```
+
+```bash
+# In ~/.zsh_autoload_functions/load_myapp_dev
+load_myapp_dev() {
+  bwss
+  eval "$(bw get notes "myapp-dev" --session "$BW_SESSION")"
+  echo "myapp-dev secrets loaded"
+}
+```
+
+### Pattern 2: Multiple Environments
+
+Switch contexts cleanly without conflicting env vars:
+
+```bash
+bwe "myapp-dev"      # loads dev secrets
+# ... work ...
+unset $(bw get notes "myapp-dev" | grep -oP '(?<=export )\w+')  # unload
+
+bwe "myapp-staging"  # load staging secrets
+```
+
+### Pattern 3: Individual Credential Loading (Gruntwork Pattern)
+
+Store a single token in a Secure Note. Use a named shell function per credential:
+
+```bash
+load_github() {
+  bwss
+  local id='e3e46z6b-a643-4j13-9820-ae4313fg75nd'  # item UUID
+  local token
+  token="$(bw get notes "$id" --session "$BW_SESSION")"
+  export GITHUB_OAUTH_TOKEN="$token"
+  export GITHUB_TOKEN="$token"
+  export GIT_TOKEN="$token"
+}
+```
+
+### Pattern 4: Custom Fields for Structured Credentials
+
+Store AWS keys as separate custom fields on a Login item:
+
+```bash
+# Retrieve individual fields
+export AWS_ACCESS_KEY_ID="$(bw get item "aws-credentials" | jq -r '.fields[] | select(.name=="AWS_ACCESS_KEY_ID") | .value')"
+export AWS_SECRET_ACCESS_KEY="$(bw get item "aws-credentials" | jq -r '.fields[] | select(.name=="AWS_SECRET_ACCESS_KEY") | .value')"
+```
+
+---
+
+## Reference Files
+
+| File | Contents |
+|------|----------|
+| [references/cli.rst](references/cli.rst) | Full `bw` CLI command reference — all flags, options, output formats |
+| [references/shell-functions.rst](references/shell-functions.rst) | Complete annotated shell function library with security notes |
+| [references/env-patterns.rst](references/env-patterns.rst) | Advanced patterns: multi-env, CI/CD, team workflows |
+
+## Example Files
+
+| File | What it does |
+|------|-------------|
+| [examples/bw-env.sh](examples/bw-env.sh) | Drop-in shell functions for .zshrc / .bashrc |
+| [examples/load-github.sh](examples/load-github.sh) | On-demand GitHub token loader (Gruntwork pattern) |
+| [examples/bw-env-format.env](examples/bw-env-format.env) | Example .env format suitable for `eval` loading |

--- a/skills/bitwarden/examples/bw-env-format.env
+++ b/skills/bitwarden/examples/bw-env-format.env
@@ -1,0 +1,17 @@
+# Example .env format for Bitwarden Secure Note storage.
+#
+# IMPORTANT: Lines MUST use the "export KEY=value" format so that
+# `eval "$(bw get notes <item>)"` correctly exports variables into the shell.
+#
+# The bwc / bwu functions in bw-env.sh automatically prepend "export "
+# to lines that are missing it when creating/updating vault items.
+#
+# Lines starting with # are comments — they will be included in the vault
+# item but are harmless when eval'd.
+
+export API_KEY=sk-your-api-key-here
+export API_SECRET=your-secret-here
+export DATABASE_URL=postgres://user:password@localhost:5432/mydb
+export REDIS_URL=redis://localhost:6379
+export APP_ENV=development
+export LOG_LEVEL=debug

--- a/skills/bitwarden/examples/bw-env.sh
+++ b/skills/bitwarden/examples/bw-env.sh
@@ -54,7 +54,7 @@ bwc() {
     return 1
   fi
   local notes
-  notes="$(awk '/^export /{ print } !/^export /{ print "export " $0 }' "$envfile")"
+  notes="$(awk '/^[[:space:]]*#/ || /^[[:space:]]*$/ { print; next } /^export / { print; next } { print "export " $0 }' "$envfile")"
   bw get template item \
     | jq --arg n "$notes" --arg name "$name" \
          '.type = 2 | .secureNote.type = 0 | .notes = $n | .name = $name' \
@@ -85,7 +85,7 @@ bwu() {
     return 1
   fi
   local notes
-  notes="$(awk '/^export /{ print } !/^export /{ print "export " $0 }' "$envfile")"
+  notes="$(awk '/^[[:space:]]*#/ || /^[[:space:]]*$/ { print; next } /^export / { print; next } { print "export " $0 }' "$envfile")"
   bw get item "$id" --session "$BW_SESSION" \
     | jq --arg n "$notes" '.notes = $n' \
     | bw encode | bw edit item "$id" --session "$BW_SESSION"
@@ -150,7 +150,7 @@ bwunload() {
   fi
   bwss
   local vars
-  vars="$(bw get notes "$1" --session "$BW_SESSION" | grep -oP '(?<=export )\w+')"
+  vars="$(bw get notes "$1" --session "$BW_SESSION" | sed -n 's/^export \([a-zA-Z_][a-zA-Z0-9_]*\)=.*/\1/p')"
   for v in $vars; do
     unset "$v"
   done

--- a/skills/bitwarden/examples/bw-env.sh
+++ b/skills/bitwarden/examples/bw-env.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# Drop-in Bitwarden shell functions for ~/.zshrc or ~/.bashrc
+# Requires: bw (Bitwarden CLI), jq
+#
+# Source this file: source /path/to/bw-env.sh
+# Or copy the functions directly into your shell config.
+
+# ---------------------------------------------------------------------------
+# Session management — unlock vault if no active session
+# ---------------------------------------------------------------------------
+bwss() {
+  if [[ -z "$BW_SESSION" ]]; then
+    >&2 echo "bw: vault locked — unlocking..."
+    export BW_SESSION="$(bw unlock --raw)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# bwe <item-name-or-uuid>
+# Load a Secure Note's content as env vars into the current shell.
+# The note must contain lines like: export KEY=value
+# ---------------------------------------------------------------------------
+bwe() {
+  if [[ -z "$1" ]]; then
+    >&2 echo "Usage: bwe <vault-item-name-or-uuid>"
+    return 1
+  fi
+  bwss
+  local notes
+  notes="$(bw get notes "$1" --session "$BW_SESSION")"
+  if [[ -z "$notes" ]]; then
+    >&2 echo "bwe: item '$1' not found or has no notes"
+    return 1
+  fi
+  eval "$notes"
+  >&2 echo "bwe: loaded '$1'"
+}
+
+# ---------------------------------------------------------------------------
+# bwc <item-name> [env-file]
+# Create a new Secure Note vault item from a .env file.
+# Default env file: .env in current directory.
+# ---------------------------------------------------------------------------
+bwc() {
+  if [[ -z "$1" ]]; then
+    >&2 echo "Usage: bwc <vault-item-name> [path-to-env-file]"
+    return 1
+  fi
+  bwss
+  local name="$1"
+  local envfile="${2:-.env}"
+  if [[ ! -f "$envfile" ]]; then
+    >&2 echo "bwc: file not found: $envfile"
+    return 1
+  fi
+  local notes
+  notes="$(awk '/^export /{ print } !/^export /{ print "export " $0 }' "$envfile")"
+  bw get template item \
+    | jq --arg n "$notes" --arg name "$name" \
+         '.type = 2 | .secureNote.type = 0 | .notes = $n | .name = $name' \
+    | bw encode | bw create item --session "$BW_SESSION"
+}
+
+# ---------------------------------------------------------------------------
+# bwu <item-name> [env-file]
+# Update an existing vault item's notes from a .env file.
+# Default env file: .env in current directory.
+# ---------------------------------------------------------------------------
+bwu() {
+  if [[ -z "$1" ]]; then
+    >&2 echo "Usage: bwu <vault-item-name> [path-to-env-file]"
+    return 1
+  fi
+  bwss
+  local name="$1"
+  local envfile="${2:-.env}"
+  if [[ ! -f "$envfile" ]]; then
+    >&2 echo "bwu: file not found: $envfile"
+    return 1
+  fi
+  local id
+  id="$(bw get item "$name" --session "$BW_SESSION" | jq -r '.id')"
+  if [[ -z "$id" || "$id" == "null" ]]; then
+    >&2 echo "bwu: item '$name' not found — use bwc to create it first"
+    return 1
+  fi
+  local notes
+  notes="$(awk '/^export /{ print } !/^export /{ print "export " $0 }' "$envfile")"
+  bw get item "$id" --session "$BW_SESSION" \
+    | jq --arg n "$notes" '.notes = $n' \
+    | bw encode | bw edit item "$id" --session "$BW_SESSION"
+  >&2 echo "bwu: updated '$name'"
+}
+
+# ---------------------------------------------------------------------------
+# bwl [search]
+# List vault item names (optionally filtered by search term).
+# ---------------------------------------------------------------------------
+bwl() {
+  bwss
+  bw list items --search "${1:-}" --session "$BW_SESSION" \
+    | jq -r '.[].name' | sort
+}
+
+# bwll [search] — list with UUIDs
+bwll() {
+  bwss
+  bw list items --search "${1:-}" --session "$BW_SESSION" \
+    | jq -r '.[] | "\(.name)\t\(.id)"' | sort
+}
+
+# ---------------------------------------------------------------------------
+# bwf <item-name> <field-name>
+# Get a single custom field value from a Login item.
+# ---------------------------------------------------------------------------
+bwf() {
+  if [[ -z "$1" || -z "$2" ]]; then
+    >&2 echo "Usage: bwf <item-name> <field-name>"
+    return 1
+  fi
+  bwss
+  bw get item "$1" --session "$BW_SESSION" \
+    | jq -r --arg f "$2" '.fields[] | select(.name == $f) | .value'
+}
+
+# ---------------------------------------------------------------------------
+# bwdd <item-name>
+# Delete a vault item by name (sends to trash — recoverable for 30 days).
+# ---------------------------------------------------------------------------
+bwdd() {
+  if [[ -z "$1" ]]; then
+    >&2 echo "Usage: bwdd <vault-item-name>"
+    return 1
+  fi
+  bwss
+  local id
+  id="$(bw get item "$1" --session "$BW_SESSION" | jq -r '.id')"
+  bw delete item "$id" --session "$BW_SESSION"
+  >&2 echo "bwdd: '$1' moved to trash"
+}
+
+# ---------------------------------------------------------------------------
+# bwunload <item-name>
+# Unset all env vars that were loaded from a given vault item.
+# ---------------------------------------------------------------------------
+bwunload() {
+  if [[ -z "$1" ]]; then
+    >&2 echo "Usage: bwunload <vault-item-name>"
+    return 1
+  fi
+  bwss
+  local vars
+  vars="$(bw get notes "$1" --session "$BW_SESSION" | grep -oP '(?<=export )\w+')"
+  for v in $vars; do
+    unset "$v"
+  done
+  >&2 echo "bwunload: unset vars from '$1'"
+}
+
+# ---------------------------------------------------------------------------
+# bwdotenv <item-name> [output-file]
+# Write vault Secure Note to a .env file (for tools that require files).
+# WARNING: Creates plaintext file. Delete after use. Never commit.
+# Default output: .env in current directory.
+# ---------------------------------------------------------------------------
+bwdotenv() {
+  if [[ -z "$1" ]]; then
+    >&2 echo "Usage: bwdotenv <vault-item-name> [output-file]"
+    return 1
+  fi
+  bwss
+  local out="${2:-.env}"
+  bw get notes "$1" --session "$BW_SESSION" \
+    | sed 's/^export //' \
+    > "$out"
+  >&2 echo "bwdotenv: wrote '$out' — DELETE THIS FILE when done, never commit it"
+}

--- a/skills/bitwarden/examples/load-github.sh
+++ b/skills/bitwarden/examples/load-github.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# On-demand GitHub token loader — Gruntwork pattern.
+#
+# Setup:
+#   1. Store your GitHub PAT as a Secure Note in Bitwarden.
+#      The note content is just the raw token (no "export" prefix needed).
+#   2. Find the item UUID:
+#        bw list items --search "GITHUB_TOKEN" | jq -r '.[0].id'
+#   3. Replace ITEM_UUID below with the actual UUID.
+#   4. Add to ~/.zshrc:
+#        fpath=(~/.zsh_autoload_functions "${fpath[@]}")
+#        autoload -Uz load_github
+#      Then copy this file to ~/.zsh_autoload_functions/load_github
+#
+# Usage (in terminal, on demand):
+#   load_github
+
+load_github() {
+  if [[ -z "$BW_SESSION" ]]; then
+    >&2 echo "bw: vault locked — unlocking..."
+    export BW_SESSION="$(bw unlock --raw)"
+  fi
+
+  # Use UUID (not name) — immune to item renames
+  local ITEM_UUID="REPLACE-WITH-YOUR-ITEM-UUID"
+
+  local token
+  token="$(bw get notes "$ITEM_UUID" --session "$BW_SESSION")"
+
+  if [[ -z "$token" ]]; then
+    >&2 echo "load_github: token not found — check ITEM_UUID and run 'bw sync'"
+    return 1
+  fi
+
+  # Export under multiple names for broad tool compatibility
+  export GITHUB_OAUTH_TOKEN="$token"
+  export GITHUB_TOKEN="$token"
+  export GIT_TOKEN="$token"
+
+  >&2 echo "load_github: GitHub token loaded (unset GITHUB_TOKEN to clear)"
+}
+
+load_github "$@"

--- a/skills/bitwarden/references/cli.rst
+++ b/skills/bitwarden/references/cli.rst
@@ -1,0 +1,264 @@
+Bitwarden Personal Password Manager CLI Reference
+=================================================
+
+This reference covers the ``bw`` CLI — the **personal Password Manager**.
+It does NOT cover ``bws`` (Bitwarden Secrets Manager).
+
+Source: https://bitwarden.com/help/cli/
+
+--------------
+
+Authentication
+--------------
+
+.. code-block:: bash
+
+   # Interactive login (prompts for email + master password + 2FA)
+   bw login
+
+   # Login with API key (non-interactive — for CI)
+   bw login --apikey
+   # Requires: BW_CLIENTID and BW_CLIENTSECRET env vars
+
+   # Check current auth status
+   bw status
+   # Returns JSON: { serverUrl, lastSync, userEmail, userId, status }
+   # status values: unauthenticated | locked | unlocked
+
+Session Management
+------------------
+
+After login, unlock the vault to get a session key:
+
+.. code-block:: bash
+
+   # Interactive unlock — prints session key
+   bw unlock
+
+   # Capture session key (most common pattern)
+   export BW_SESSION="$(bw unlock --raw)"
+
+   # Non-interactive unlock using an env var for the master password
+   export BW_PASSWORD="mypassword"
+   export BW_SESSION="$(bw unlock --passwordenv BW_PASSWORD --raw)"
+
+   # Non-interactive unlock from a file
+   export BW_SESSION="$(bw unlock --passwordfile /path/to/pwfile --raw)"
+
+   # Pass session inline (single command, no export needed)
+   bw get item "myitem" --session "$BW_SESSION"
+
+   # Lock the vault (invalidates session)
+   bw lock
+
+   # Logout (removes local data)
+   bw logout
+
+Sync
+----
+
+Vault data is cached locally. Sync to pull the latest from the server:
+
+.. code-block:: bash
+
+   bw sync                # pull latest from server
+   bw sync --last         # print timestamp of last sync
+
+--------------
+
+Retrieving Items (``bw get``)
+-----------------------------
+
+.. code-block:: bash
+
+   # Get an item by name or UUID
+   bw get item "my-api-key"
+   bw get item "abc1234-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+
+   # Get specific fields directly
+   bw get password "my-login-item"
+   bw get username "my-login-item"
+   bw get uri "my-login-item"
+   bw get totp "my-login-item"
+
+   # Get the Notes field of an item (key for .env patterns)
+   bw get notes "myapp-dev"
+   bw get notes "abc1234-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+
+   # Get an attachment
+   bw get attachment "filename.txt" --itemid "abc1234-..."
+
+   # Get a folder
+   bw get folder "Development"
+
+Important flags:
+- Use ``--raw`` to suppress extra output (only returns the value)
+- Pass ``--session`` to avoid relying on the env var
+
+Listing Items (``bw list``)
+---------------------------
+
+.. code-block:: bash
+
+   # List all items
+   bw list items
+
+   # Search by name
+   bw list items --search "myapp"
+
+   # Filter by folder ID
+   bw list items --folderid "folder-uuid"
+
+   # Pretty-print JSON
+   bw list items --pretty
+
+   # List just names (jq)
+   bw list items | jq -r '.[].name'
+
+   # List names with IDs
+   bw list items | jq -r '.[] | "\(.id)\t\(.name)"'
+
+   # List folders
+   bw list folders
+
+Creating Items (``bw create``)
+------------------------------
+
+The workflow is always: get template → edit with jq → encode → create.
+
+.. code-block:: bash
+
+   # See the item template structure
+   bw get template item
+
+   # Create a Secure Note (type=2) from a .env file
+   bw get template item \
+     | jq --rawfile notes .env \
+          --arg name "myapp-dev" \
+          '.type = 2 | .secureNote.type = 0 | .notes = $notes | .name = $name' \
+     | bw encode | bw create item
+
+   # Create a Login item (type=1) with custom fields
+   bw get template item \
+     | jq --arg name "GITHUB_TOKEN" \
+          --arg secret "ghp_xxxx" \
+          '.type = 1 | .name = $name |
+           .fields = [{"name":"value","value":$secret,"type":1}]' \
+     | bw encode | bw create item
+
+   # Create a folder
+   bw get template folder | jq '.name = "Development"' | bw encode | bw create folder
+
+Item Types
+~~~~~~~~~~
+
+=====  ============
+Type   Description
+=====  ============
+1      Login
+2      Secure Note
+3      Card
+4      Identity
+5      SSH Key
+=====  ============
+
+Custom Field Types
+~~~~~~~~~~~~~~~~~~
+
+=====  ============
+Type   Description
+=====  ============
+0      Text (visible)
+1      Hidden (masked — use for secrets)
+2      Boolean
+=====  ============
+
+Editing Items (``bw edit``)
+----------------------------
+
+.. code-block:: bash
+
+   # Update an item — always get first, modify, then edit
+   bw get item "myapp-dev" \
+     | jq --rawfile notes .env '.notes = $notes' \
+     | bw encode | bw edit item "abc1234-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+
+Deleting Items (``bw delete``)
+-------------------------------
+
+.. code-block:: bash
+
+   # Move to trash (recoverable for 30 days)
+   bw delete item "abc1234-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+
+   # Permanent delete (irreversible)
+   bw delete item "abc1234-xxxx-xxxx-xxxx-xxxxxxxxxxxx" --permanent
+
+   # Get item ID from name, then delete
+   ID=$(bw get item "myapp-dev" | jq -r '.id')
+   bw delete item "$ID"
+
+   # Restore from trash
+   bw restore item "abc1234-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+
+--------------
+
+Global Flags
+------------
+
+``--session <key>``
+    Pass session key inline instead of using ``$BW_SESSION`` env var.
+
+``--raw``
+    Return only the value with no decorative output. Essential for scripting.
+
+``--pretty``
+    Pretty-print JSON output.
+
+``--nointeraction``
+    Disable interactive prompts. Required for non-interactive/CI use.
+
+``--quiet``
+    Suppress stdout (useful in scripts where only exit code matters).
+
+--------------
+
+Environment Variables
+---------------------
+
+``BW_SESSION``
+    Active session key. Set this after ``bw unlock --raw``.
+
+``BW_CLIENTID`` / ``BW_CLIENTSECRET``
+    API key credentials for non-interactive login (``bw login --apikey``).
+
+``BITWARDENCLI_APPDATA_DIR``
+    Override config/data directory. Useful for multiple account setups.
+
+``BITWARDENCLI_DEBUG=true``
+    Enable verbose debug output.
+
+``NODE_EXTRA_CA_CERTS``
+    Path to CA bundle for self-signed certificate environments.
+
+--------------
+
+Useful jq Patterns
+------------------
+
+.. code-block:: bash
+
+   # Get notes field (raw, no quotes)
+   bw get item "name" | jq -r '.notes'
+
+   # Get a custom field by name
+   bw get item "name" | jq -r '.fields[] | select(.name=="MY_KEY") | .value'
+
+   # List all custom field names
+   bw get item "name" | jq -r '.fields[].name'
+
+   # Get item ID from name
+   bw get item "name" | jq -r '.id'
+
+   # Format name+id table from list
+   bw list items | jq -r '.[] | "\(.name)\t\(.id)"'

--- a/skills/bitwarden/references/env-patterns.rst
+++ b/skills/bitwarden/references/env-patterns.rst
@@ -142,12 +142,7 @@ values without parsing.
      bwss
      local item
      item="$(bw get item "aws-credentials" --session "$BW_SESSION")"
-     while IFS= read -r line; do
-       local name value
-       name="$(echo "$line" | jq -r '.name')"
-       value="$(echo "$line" | jq -r '.value')"
-       export "$name"="$value"
-     done < <(echo "$item" | jq -c '.fields[]')
+     eval "$(echo "$item" | jq -r '.fields[] | "export \(.name)=\(.value | @sh)"')"
      >&2 echo "AWS credentials loaded"
    }
 

--- a/skills/bitwarden/references/env-patterns.rst
+++ b/skills/bitwarden/references/env-patterns.rst
@@ -1,0 +1,211 @@
+Advanced .env Patterns with Bitwarden CLI
+==========================================
+
+Patterns for common development workflows: multi-environment switching,
+CI/CD, team workflows, and integrating with tools that read ``.env`` files.
+
+--------------
+
+Pattern 1: Multi-Environment Switching
+---------------------------------------
+
+Store separate items per environment. Switch without file management.
+
+.. code-block:: bash
+
+   # Vault items: myapp-dev, myapp-staging, myapp-prod
+
+   # Load dev
+   bwe "myapp-dev"
+
+   # Unload dev, load staging
+   bwunload "myapp-dev"
+   bwe "myapp-staging"
+
+Naming convention: ``<project>-<env>`` makes ``bwl myapp`` return all
+environments sorted together.
+
+--------------
+
+Pattern 2: Generate .env File on Demand (for tools that require files)
+-----------------------------------------------------------------------
+
+Some tools (Docker Compose, ``dotenv`` libraries) require an actual ``.env``
+file. Generate it on demand from the vault, use it, then delete it.
+
+.. code-block:: bash
+
+   bwdotenv() {
+     bwss
+     local item="$1"
+     local out="${2:-.env}"
+     bw get notes "$item" --session "$BW_SESSION" \
+       | sed 's/^export //' \
+       > "$out"
+     >&2 echo "bwdotenv: wrote '$out' (remember to delete after use)"
+   }
+
+   # Usage — generate, run, delete
+   bwdotenv "myapp-dev"
+   docker compose up
+   rm .env
+
+**Warning:** Files on disk are less secure than env vars in memory.
+Only write to disk when absolutely required by the toolchain.
+Never commit the generated ``.env``.
+
+--------------
+
+Pattern 3: CI/CD (GitHub Actions, GitLab CI)
+----------------------------------------------
+
+In CI, use the Bitwarden API key login (no interactive password prompt).
+Store ``BW_CLIENTID``, ``BW_CLIENTSECRET``, and ``BW_PASSWORD`` as
+repository/pipeline secrets in your CI platform.
+
+**GitHub Actions example:**
+
+.. code-block:: yaml
+
+   - name: Install Bitwarden CLI
+     run: npm install -g @bitwarden/cli
+
+   - name: Load secrets from Bitwarden
+     env:
+       BW_CLIENTID: ${{ secrets.BW_CLIENTID }}
+       BW_CLIENTSECRET: ${{ secrets.BW_CLIENTSECRET }}
+       BW_PASSWORD: ${{ secrets.BW_PASSWORD }}
+     run: |
+       bw login --apikey
+       export BW_SESSION="$(bw unlock --passwordenv BW_PASSWORD --raw)"
+       bw get notes "myapp-ci" | sed 's/^export //' >> "$GITHUB_ENV"
+
+The ``>> $GITHUB_ENV`` pattern makes variables available to subsequent steps.
+
+**Note:** This bootstraps Bitwarden with a small set of CI platform secrets.
+The tradeoff: you still need 3 CI secrets, but in return you can store
+unlimited application secrets in one Bitwarden item.
+
+--------------
+
+Pattern 4: direnv Integration
+------------------------------
+
+`direnv <https://direnv.net/>`_ loads ``.envrc`` when you ``cd`` into a directory.
+Use it to trigger Bitwarden loading automatically per project.
+
+**.envrc:**
+
+.. code-block:: bash
+
+   # .envrc — committed to git (contains no secrets)
+   # Requires: bwss function in ~/.zshrc, bw installed
+   if command -v bw &>/dev/null; then
+     bwss
+     eval "$(bw get notes "myapp-dev" --session "$BW_SESSION")"
+   fi
+
+Approve once with ``direnv allow``. Secrets load on ``cd``, unload on ``cd`` out.
+
+**Caution:** This auto-loads secrets on every directory entry. If the
+vault is locked you'll be prompted for the master password on every ``cd``.
+Better suited for projects with frequent context switching.
+
+--------------
+
+Pattern 5: Storing Structured Credentials as Custom Fields
+-----------------------------------------------------------
+
+For credentials with multiple related keys (AWS, database), use a Login item
+with custom fields instead of a Secure Note. This lets you retrieve individual
+values without parsing.
+
+**Create the item:**
+
+.. code-block:: bash
+
+   bw get template item | jq \
+     --arg name "aws-credentials" \
+     '.type = 1 | .name = $name |
+      .fields = [
+        {"name":"AWS_ACCESS_KEY_ID","value":"AKIAIOSFODNN7EXAMPLE","type":1},
+        {"name":"AWS_SECRET_ACCESS_KEY","value":"wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY","type":1},
+        {"name":"AWS_DEFAULT_REGION","value":"eu-west-1","type":0}
+      ]' \
+     | bw encode | bw create item
+
+**Load all fields into env vars:**
+
+.. code-block:: bash
+
+   load_aws() {
+     bwss
+     local item
+     item="$(bw get item "aws-credentials" --session "$BW_SESSION")"
+     while IFS= read -r line; do
+       local name value
+       name="$(echo "$line" | jq -r '.name')"
+       value="$(echo "$line" | jq -r '.value')"
+       export "$name"="$value"
+     done < <(echo "$item" | jq -c '.fields[]')
+     >&2 echo "AWS credentials loaded"
+   }
+
+--------------
+
+Pattern 6: Syncing Secrets Across Machines
+-------------------------------------------
+
+Bitwarden vaults sync automatically. The workflow across machines:
+
+.. code-block:: bash
+
+   # New machine setup
+   bw login                              # authenticate once
+   export BW_SESSION="$(bw unlock --raw)"
+   bw sync                               # pull latest vault
+   bwe "myapp-dev"                       # load secrets
+
+No copying `.env` files between machines. Rotate a key once in the vault;
+all machines get the new value on next sync.
+
+--------------
+
+Pattern 7: Rotating Secrets
+----------------------------
+
+.. code-block:: bash
+
+   # Get existing item, update the notes, save back
+   # bwu "myapp-dev" new.env       — updates from a new .env file
+   # Or edit inline:
+
+   bwrotate() {
+     bwss
+     local item_name="$1"
+     local field_name="$2"
+     local new_value="$3"
+     local id
+     id="$(bw get item "$item_name" --session "$BW_SESSION" | jq -r '.id')"
+     bw get item "$id" --session "$BW_SESSION" \
+       | jq --arg f "$field_name" --arg v "$new_value" \
+            '(.fields[] | select(.name == $f) | .value) = $v' \
+       | bw encode | bw edit item "$id" --session "$BW_SESSION"
+     bw sync
+   }
+
+   # Usage: bwrotate "github-credentials" "GITHUB_TOKEN" "ghp_newvalue"
+
+--------------
+
+What NOT to Do
+--------------
+
+- **Do not** store ``BW_SESSION`` in ``.env``, shell history, or config files.
+- **Do not** use ``bw login`` with credentials inline in shell history
+  (``bw login email@example.com mysecretpassword``). Use interactive mode.
+- **Do not** auto-load secrets at shell startup for all terminals —
+  load on-demand per project.
+- **Do not** use ``set -x`` / ``bash -x`` in scripts that handle secrets.
+- **Do not** ``echo "$BW_SESSION"`` or pipe it through commands that log.
+- **Do not** confuse ``bw`` (personal PM) with ``bws`` (Secrets Manager).

--- a/skills/bitwarden/references/shell-functions.rst
+++ b/skills/bitwarden/references/shell-functions.rst
@@ -1,0 +1,242 @@
+Bitwarden Shell Functions Reference
+====================================
+
+Complete annotated shell function library for ``.zshrc`` / ``.bashrc``.
+All functions assume ``jq`` and ``bw`` are installed and on ``PATH``.
+
+The full drop-in script is at ``examples/bw-env.sh``.
+
+--------------
+
+Session Guard
+-------------
+
+Always call this before any ``bw`` command. It unlocks only when no active
+session exists in the current shell — avoids redundant password prompts.
+
+.. code-block:: bash
+
+   bwss() {
+     if [[ -z "$BW_SESSION" ]]; then
+       >&2 echo "bw: vault locked — unlocking..."
+       export BW_SESSION="$(bw unlock --raw)"
+     fi
+   }
+
+Why ``>&2``? Debug/status messages go to stderr so they don't pollute
+stdout when the caller is capturing output (e.g., ``val=$(bwss && bw get ...)``).
+
+--------------
+
+Load .env Block from Vault (Core Function)
+-------------------------------------------
+
+Loads all variables from a Secure Note into the current shell.
+
+.. code-block:: bash
+
+   # bwe <vault-item-name-or-uuid>
+   bwe() {
+     bwss
+     local notes
+     notes="$(bw get notes "$1" --session "$BW_SESSION")"
+     if [[ -z "$notes" ]]; then
+       >&2 echo "bwe: item '$1' not found or has no notes"
+       return 1
+     fi
+     eval "$notes"
+     >&2 echo "bwe: loaded '$1'"
+   }
+
+**Requirement:** The Secure Note's content must be lines of:
+
+.. code-block:: bash
+
+   export KEY=value
+   export ANOTHER_KEY="value with spaces"
+
+See ``examples/bw-env-format.env`` for the expected format.
+
+--------------
+
+Create Vault Item from .env File
+----------------------------------
+
+Stores a .env file as a new Secure Note in the vault.
+
+.. code-block:: bash
+
+   # bwc <vault-item-name> [path-to-env-file]
+   # Default env file: .env in current directory
+   bwc() {
+     bwss
+     local name="$1"
+     local envfile="${2:-.env}"
+     if [[ ! -f "$envfile" ]]; then
+       >&2 echo "bwc: file not found: $envfile"
+       return 1
+     fi
+     # Prepend 'export' to any lines that don't already have it
+     local notes
+     notes="$(awk '/^export /{ print } !/^export /{ print "export " $0 }' "$envfile")"
+     bw get template item \
+       | jq --arg n "$notes" --arg name "$name" \
+            '.type = 2 | .secureNote.type = 0 | .notes = $n | .name = $name' \
+       | bw encode | bw create item --session "$BW_SESSION"
+   }
+
+--------------
+
+Update Vault Item Notes from .env File
+----------------------------------------
+
+Replace the notes on an existing vault item.
+
+.. code-block:: bash
+
+   # bwu <vault-item-name> [path-to-env-file]
+   bwu() {
+     bwss
+     local name="$1"
+     local envfile="${2:-.env}"
+     if [[ ! -f "$envfile" ]]; then
+       >&2 echo "bwu: file not found: $envfile"
+       return 1
+     fi
+     local id
+     id="$(bw get item "$name" --session "$BW_SESSION" | jq -r '.id')"
+     if [[ -z "$id" || "$id" == "null" ]]; then
+       >&2 echo "bwu: item '$name' not found"
+       return 1
+     fi
+     local notes
+     notes="$(awk '/^export /{ print } !/^export /{ print "export " $0 }' "$envfile")"
+     bw get item "$id" --session "$BW_SESSION" \
+       | jq --arg n "$notes" '.notes = $n' \
+       | bw encode | bw edit item "$id" --session "$BW_SESSION"
+   }
+
+--------------
+
+List Vault Items
+-----------------
+
+.. code-block:: bash
+
+   # bwl [search-term]   — list all item names (optionally filtered)
+   bwl() {
+     bwss
+     bw list items --search "${1:-}" --session "$BW_SESSION" \
+       | jq -r '.[].name' | sort
+   }
+
+   # bwll [search-term]  — list with UUIDs (useful for scripting)
+   bwll() {
+     bwss
+     bw list items --search "${1:-}" --session "$BW_SESSION" \
+       | jq -r '.[] | "\(.name)\t\(.id)"' | sort
+   }
+
+--------------
+
+Get a Single Custom Field Value
+--------------------------------
+
+For Login items with custom fields (not Secure Notes):
+
+.. code-block:: bash
+
+   # bwf <item-name> <field-name>
+   bwf() {
+     bwss
+     bw get item "$1" --session "$BW_SESSION" \
+       | jq -r --arg f "$2" '.fields[] | select(.name == $f) | .value'
+   }
+
+   # Usage:
+   # export GITHUB_TOKEN="$(bwf "github-credentials" "GITHUB_TOKEN")"
+
+--------------
+
+Delete a Vault Item by Name
+-----------------------------
+
+.. code-block:: bash
+
+   # bwdd <vault-item-name>   — sends to trash (recoverable)
+   bwdd() {
+     bwss
+     local id
+     id="$(bw get item "$1" --session "$BW_SESSION" | jq -r '.id')"
+     bw delete item "$id" --session "$BW_SESSION"
+     >&2 echo "bwdd: '$1' moved to trash"
+   }
+
+--------------
+
+On-Demand Named Loaders (Gruntwork Pattern)
+--------------------------------------------
+
+Define per-project functions that are autoloaded but never run at shell startup.
+This means secrets are never in memory unless you explicitly call the function.
+
+**~/.zshrc:**
+
+.. code-block:: bash
+
+   fpath=(~/.zsh_autoload_functions "${fpath[@]}")
+   autoload -Uz load_github load_myapp_dev load_aws
+
+**~/.zsh_autoload_functions/load_github:**
+
+.. code-block:: bash
+
+   load_github() {
+     bwss
+     local id="e3e46z6b-a643-4j13-9820-ae4313fg75nd"  # item UUID (use ID not name)
+     local token
+     token="$(bw get notes "$id" --session "$BW_SESSION")"
+     export GITHUB_OAUTH_TOKEN="$token"
+     export GITHUB_TOKEN="$token"
+     export GIT_TOKEN="$token"
+     >&2 echo "GitHub token loaded"
+   }
+
+   load_github "$@"
+
+Using the UUID (not the name) prevents breakage if the item is renamed.
+
+--------------
+
+Unloading Secrets
+-----------------
+
+Explicitly unset env vars loaded from a Secure Note:
+
+.. code-block:: bash
+
+   # bwunload <vault-item-name>
+   bwunload() {
+     bwss
+     local vars
+     vars="$(bw get notes "$1" --session "$BW_SESSION" \
+       | grep -oP '(?<=export )\w+')"
+     for v in $vars; do
+       unset "$v"
+     done
+     >&2 echo "bwunload: unset vars from '$1'"
+   }
+
+--------------
+
+Security Notes
+--------------
+
+- ``BW_SESSION`` is a **decryption key** for your entire vault. Never write it
+  to disk, log it, or expose it in ``ps`` output. Keep it in memory only.
+- Never ``set -x`` (xtrace) when a session key or secret is on the line — it
+  will print to stderr/logs.
+- Use ``type=1`` (hidden) for custom fields that contain secrets, not ``type=0``
+  (text). Hidden fields are masked in the web UI.
+- Prefer UUID references (``bw get notes <uuid>``) in permanent scripts to avoid
+  breakage from item renames.


### PR DESCRIPTION
## Summary

Adds a new `/bitwarden` skill for managing development secrets and `.env` variables using the **Bitwarden personal Password Manager CLI** (`bw`).

> **CRITICAL:** This skill targets the personal Password Manager — NOT Bitwarden Secrets Manager (`bws`). This distinction is explicitly documented throughout.

## What's included

| File | Purpose |
|------|---------|
| `SKILL.md` | Quick-start, naming conventions, security rules, core patterns |
| `references/cli.rst` | Full `bw` CLI reference — auth, session, CRUD, jq patterns |
| `references/shell-functions.rst` | Annotated `bwss`/`bwe`/`bwc`/`bwu`/`bwl`/`bwf`/`bwdd`/`bwunload` library |
| `references/env-patterns.rst` | Advanced patterns: multi-env, CI/CD, direnv, rotation |
| `examples/bw-env.sh` | Drop-in shell functions for `.zshrc`/`.bashrc` |
| `examples/load-github.sh` | Gruntwork-pattern per-credential named loader |
| `examples/bw-env-format.env` | Example `.env` format for vault storage |

## Key design decisions

- **On-demand loading** — secrets load into the current shell only when needed; gone when terminal closes
- **`BW_SESSION` in memory only** — never written to disk or logged
- **UUID references** in permanent scripts — immune to vault item renames
- **Secure Note pattern** for `.env` blocks; **custom fields** for structured multi-key credentials
- Security "What NOT to Do" section covering common mistakes

## Research sources

- [Bitwarden Password Manager CLI docs](https://bitwarden.com/help/cli/)
- [Gruntwork: Securely store secrets in BitWarden CLI](https://www.gruntwork.io/blog/how-to-securely-store-secrets-in-bitwarden-cli-and-load-them-into-your-zsh-shell-when-needed)
- [DEV.to: Manage Dev Secrets and Dotenv Files with Bitwarden CLI](https://dev.to/stevengonsalvez/password-manage-your-environment-and-secrets-with-bitwarden-13n5)
- [drumm.sh: More Bitwarden CLI Shell Scripting](https://www.drumm.sh/blog/2021/09/17/more-bw-cli/)