### PR TITLE
chore: add missing changelog fragment for bitwarden skill

### DIFF
--- a/.changes/unreleased/Added-bitwarden-skill.yaml
+++ b/.changes/unreleased/Added-bitwarden-skill.yaml
@@ -1,0 +1,2 @@
+kind: Added
+body: Add Bitwarden personal PM skill for .env & dev secrets management


### PR DESCRIPTION
Adds a missing changie fragment for the Bitwarden skill to fix the CI Changelog Check failure.

---
*PR created automatically by Jules for task [5240079731808484627](https://jules.google.com/task/5240079731808484627) started by @rudolfjs*