### PR TITLE
feat(sops): polish and ship age + vault skill

### DIFF
--- a/.changes/unreleased/Added-20260420-sops-skill.yaml
+++ b/.changes/unreleased/Added-20260420-sops-skill.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: New `sops` skill for encrypting `.env`, YAML, and JSON secrets with Age or HashiCorp Vault transit
+time: 2026-04-20T10:57:27.449259794+10:00

--- a/.changes/unreleased/Added-20260420-sops-skill.yaml
+++ b/.changes/unreleased/Added-20260420-sops-skill.yaml
@@ -1,3 +1,3 @@
 kind: Added
-body: New `sops` skill for encrypting `.env`, YAML, and JSON secrets with Age or HashiCorp Vault transit
+body: New `sops` skill for encrypting `.env`, YAML, JSON, and INI secrets with Age or HashiCorp Vault transit
 time: 2026-04-20T10:57:27.449259794+10:00

--- a/docs/skill-creation/skills-registry.mdx
+++ b/docs/skill-creation/skills-registry.mdx
@@ -45,6 +45,7 @@ Skills with no `scripts/` directory are pure prompt skills (SKILL.md + optional 
 | `shiny-bslib` | — | Shiny apps with bslib components |
 | `shiny-bslib-theming` | — | bslib theming for Shiny apps |
 | `skill-review` | — | Self-improvement loop for Claude Code skills |
+| `sops` | — | SOPS encryption (Age, HashiCorp Vault) for YAML/JSON/ENV/INI secrets |
 | `starrocks` | — | StarRocks analytical data warehouse |
 | `tdd` | — | TDD concepts, red→green→refactor cycle, anti-patterns |
 | `tdd-team-workflow` | Bash | TDD orchestration workflow — phase sequencing, state tracking |

--- a/skills/sops/SKILL.md
+++ b/skills/sops/SKILL.md
@@ -1,38 +1,105 @@
 ---
 name: sops
-description: >-
-  Encrypt and decrypt files using SOPS (Secrets OPerationS).
-  Trigger when the user asks to encrypt .env files, config files,
-  or secrets using SOPS + Age or SOPS + HashiCorp Vault.
 license: MIT
+description: >-
+  Use when encrypting or decrypting `.env`, `.yaml`, `.json`, or `.ini` secrets
+  — even if the user does not say "SOPS" explicitly. Triggers on: storing
+  secrets in Git safely, Age encryption, HashiCorp Vault transit, `sops_age_key_file`,
+  `SOPS_AGE_RECIPIENTS`, `VAULT_ADDR`, or any request to keep config files
+  secret while keeping diffs reviewable. Covers key generation, `.sops.yaml`
+  creation rules, in-place editing, multi-recipient setups, and key rotation
+  with `sops updatekeys`. Load for `.env`, YAML, JSON, INI, and binary file
+  encryption tasks even when the user reaches for words like "encrypt my
+  cluster secrets", "seal this config", or "share secrets with my team".
+compatibility: >-
+  Requires sops CLI; and either age (for Age backend) or a HashiCorp Vault
+  instance with the transit engine enabled (for Vault backend)
 metadata:
   repo: https://github.com/nq-rdl/agent-skills
 ---
 
 # SOPS Encryption Skill
 
-This skill teaches how to encrypt and decrypt files using [SOPS](https://github.com/getsops/sops). SOPS supports YAML, JSON, ENV, INI, and BINARY formats. It supports various KMS backends. This skill focuses on encrypting with **Age** and **HashiCorp Vault**.
+Encrypt and decrypt secrets with [SOPS](https://github.com/getsops/sops) (Secrets OPerationS). SOPS encrypts only the *leaf values* in YAML/JSON/ENV/INI/BINARY files — keys stay in plaintext, keeping diffs reviewable in Git. This skill covers the **Age** and **HashiCorp Vault** backends.
 
-## When to use this skill
+---
 
-- The user wants to encrypt secrets for infrastructure as code, CI/CD, or deployment.
-- The user explicitly mentions SOPS, Age, or HashiCorp Vault for encryption.
-- The user asks to encrypt an `.env`, `.yaml`, or `.json` file containing sensitive data.
+## Quick Reference
+
+| Operation | Command | Reference |
+|-----------|---------|-----------|
+| Encrypt (Age) | `sops encrypt --age <pubkey> file.yaml > file.enc.yaml` | [age.rst](references/age.rst) |
+| Encrypt (Vault) | `sops encrypt --hc-vault-transit $VAULT_ADDR/v1/sops/keys/mykey file.yaml` | [vault.rst](references/vault.rst) |
+| Decrypt to stdout | `sops decrypt file.enc.yaml` | [age.rst](references/age.rst) |
+| Edit in place | `sops edit file.enc.yaml` | [age.rst](references/age.rst) |
+| Rotate recipients | `sops updatekeys file.enc.yaml` | [age.rst](references/age.rst) / [vault.rst](references/vault.rst) |
+| Init `.sops.yaml` | Add `creation_rules` to project root | both references |
+
+---
 
 ## The Encryption Flow
 
-1. **Identify the format**: Ensure the file to be encrypted is in a supported format (YAML, JSON, ENV, INI) so SOPS can extract keys and only encrypt leaf values.
-2. **Choose the backend**: Follow the user's instructions to use either Age or HashiCorp Vault.
-3. **Execute**: Use the `sops` CLI tool to perform the encryption.
+1. **Identify the format** — SOPS auto-detects from the file extension (`.yaml`, `.json`, `.env`, `.ini`). Use `--input-type` / `--output-type` only when the extension is ambiguous.
+2. **Choose the backend** — Age for simplicity (key file on disk); Vault for centralised, audited key management.
+3. **Configure recipients** — either pass `--age` / `--hc-vault-transit` on the CLI, or commit a `.sops.yaml` at the project root so SOPS picks up the right key automatically.
+4. **Execute** — `sops encrypt`, `sops decrypt`, or `sops edit` as needed.
 
-## Best Practices
+---
 
-- Always keep the file extension the same so SOPS knows how to decrypt it (e.g. `sops encrypt -i myfile.json`).
-- If you need to change the extension after encryption, provide `--input-type` and `--output-type`.
-- The SOPS CLI works by encrypting leaf values, not keys. This means the diffs in Git will be readable!
-- Top-level arrays in YAML/JSON are not supported. Put arrays inside an object (e.g. `{"data": [...]}`).
+## Generating an Age Key
+
+```bash
+age-keygen -o "$HOME/.config/sops/age/keys.txt"
+```
+
+The public key is printed to **stderr** — copy it into `--age` or `.sops.yaml`. The private key written to `keys.txt` is what SOPS uses for decryption. See [age.rst](references/age.rst) for default lookup paths on Linux and macOS.
+
+---
+
+## `.sops.yaml` Workflow
+
+A `.sops.yaml` at the project root tells SOPS which key to use for each path, so you never need to pass `--age` or `--hc-vault-transit` manually:
+
+```yaml
+creation_rules:
+  - path_regex: ^(secrets/|\.env)
+    encrypted_regex: ^(data|stringData|password|token|secret)$
+    age: >-
+      age1yt3tfqlfrwdwx0z0ynwplcr6qxcxfaqycuprpmy89nr83ltx74tqdpszlw,
+      age1s3cqcks5genc6ru8chl0hkkd04zmxvczsvdxq99ekffe4gmvjpzsedk23c
+```
+
+`encrypted_regex` scopes encryption to matching *keys* only — useful for Kubernetes secrets where you want `data` and `stringData` encrypted but not the rest of the manifest. Omit it to encrypt all leaf values.
+
+---
+
+## Key Rotation
+
+After updating `.sops.yaml` with new recipients, re-encrypt the data key without touching plaintext values:
+
+```bash
+sops updatekeys secrets/prod.yaml
+```
+
+See the rotation subsections in [age.rst](references/age.rst) and [vault.rst](references/vault.rst) for backend-specific steps.
+
+---
+
+## Gotchas
+
+- **SOPS encrypts values, not keys.** Key names stay in plaintext — diffs remain reviewable, but don't put secrets in key names.
+- **Top-level arrays are not supported.** Wrap arrays in an object: `{"data": [...]}` instead of `[...]`.
+- **Keep the file extension stable.** SOPS detects format from the extension at decrypt time. Renaming `.yaml` to `.txt` causes a parse failure — use `--input-type` / `--output-type` if you must change it.
+- **`.env` files decrypt to stdout by default.** Pipe to a file (`sops decrypt .env.enc > .env`) or use `sops decrypt -i .env.enc` for in-place decryption.
+- **`SOPS_AGE_KEY_FILE` must point at an existing file.** If the variable is set but the file is missing, SOPS fails with a confusing "no key found" error rather than "file not found".
+- **Vault credentials must be present at both encrypt *and* decrypt time.** `VAULT_ADDR` and a valid token (env var or `~/.vault-token`) are required by both operations — not just encryption.
+- **Don't commit the age private key.** Only the public key belongs in `.sops.yaml` or `--age`. The private key file (`keys.txt`) should be in `.gitignore`.
+
+---
 
 ## Reference Guides
 
-- [Encrypting with Age](references/age.rst)
-- [Encrypting with HashiCorp Vault](references/vault.rst)
+Load the appropriate reference based on the backend in use:
+
+- [**Encrypting with Age**](references/age.rst) — Age key generation, encryption, decryption, in-place editing, SSH key support, and recipient rotation. Load this when the user is using Age or mentions `age-keygen`, `SOPS_AGE_KEY_FILE`, or `SOPS_AGE_RECIPIENTS`.
+- [**Encrypting with HashiCorp Vault**](references/vault.rst) — Vault transit engine setup, authentication (token / AppRole), encryption, decryption, and key rotation with `vault write -f .../rotate`. Load this when the user mentions Vault, `VAULT_ADDR`, or `hc_vault_transit_uri`.

--- a/skills/sops/SKILL.md
+++ b/skills/sops/SKILL.md
@@ -4,7 +4,7 @@ license: MIT
 description: >-
   Use when encrypting or decrypting `.env`, `.yaml`, `.json`, or `.ini` secrets
   — even if the user does not say "SOPS" explicitly. Triggers on: storing
-  secrets in Git safely, Age encryption, HashiCorp Vault transit, `sops_age_key_file`,
+  secrets in Git safely, Age encryption, HashiCorp Vault transit, `SOPS_AGE_KEY_FILE`,
   `SOPS_AGE_RECIPIENTS`, `VAULT_ADDR`, or any request to keep config files
   secret while keeping diffs reviewable. Covers key generation, `.sops.yaml`
   creation rules, in-place editing, multi-recipient setups, and key rotation
@@ -29,7 +29,7 @@ Encrypt and decrypt secrets with [SOPS](https://github.com/getsops/sops) (Secret
 | Operation | Command | Reference |
 |-----------|---------|-----------|
 | Encrypt (Age) | `sops encrypt --age <pubkey> file.yaml > file.enc.yaml` | [age.rst](references/age.rst) |
-| Encrypt (Vault) | `sops encrypt --hc-vault-transit $VAULT_ADDR/v1/sops/keys/mykey file.yaml` | [vault.rst](references/vault.rst) |
+| Encrypt (Vault) | `sops encrypt --hc-vault-transit $VAULT_ADDR/v1/sops/keys/mykey file.yaml > file.enc.yaml` | [vault.rst](references/vault.rst) |
 | Decrypt to stdout | `sops decrypt file.enc.yaml` | [age.rst](references/age.rst) |
 | Edit in place | `sops edit file.enc.yaml` | [age.rst](references/age.rst) |
 | Rotate recipients | `sops updatekeys file.enc.yaml` | [age.rst](references/age.rst) / [vault.rst](references/vault.rst) |
@@ -49,6 +49,7 @@ Encrypt and decrypt secrets with [SOPS](https://github.com/getsops/sops) (Secret
 ## Generating an Age Key
 
 ```bash
+mkdir -p "$HOME/.config/sops/age"
 age-keygen -o "$HOME/.config/sops/age/keys.txt"
 ```
 

--- a/skills/sops/references/age.rst
+++ b/skills/sops/references/age.rst
@@ -10,6 +10,7 @@ Generate an age identity (private + public key pair) with:
 
 .. code-block:: bash
 
+   mkdir -p "$HOME/.config/sops/age"
    age-keygen -o "$HOME/.config/sops/age/keys.txt"
 
 The **public key** is printed to stderr — copy it into ``--age`` flags or ``.sops.yaml``. The private key is written to ``keys.txt`` and must be kept secret. Only the public key is shared with others.

--- a/skills/sops/references/age.rst
+++ b/skills/sops/references/age.rst
@@ -3,6 +3,24 @@ Encrypting with Age
 
 `Age <https://age-encryption.org/>`_ is a simple, modern, and secure tool for encrypting files. It is recommended to use age over PGP if possible.
 
+Generating a Key
+----------------
+
+Generate an age identity (private + public key pair) with:
+
+.. code-block:: bash
+
+   age-keygen -o "$HOME/.config/sops/age/keys.txt"
+
+The **public key** is printed to stderr — copy it into ``--age`` flags or ``.sops.yaml``. The private key is written to ``keys.txt`` and must be kept secret. Only the public key is shared with others.
+
+SOPS looks for ``keys.txt`` at decryption time using the following default paths:
+
+- **Linux**: ``$XDG_CONFIG_HOME/sops/age/keys.txt`` → falls back to ``$HOME/.config/sops/age/keys.txt``
+- **macOS**: ``$XDG_CONFIG_HOME/sops/age/keys.txt`` → falls back to ``$HOME/Library/Application Support/sops/age/keys.txt``
+
+Override the default path with the ``SOPS_AGE_KEY_FILE`` environment variable. If ``SOPS_AGE_KEY_FILE`` is set but points at a missing file, decryption fails with a confusing error — verify the path before setting the variable.
+
 Encrypting
 ----------
 
@@ -28,6 +46,17 @@ You can override the default lookup by:
 
 The contents of this key file should be a list of age X25519 identities, one per line. Lines beginning with ``#`` are considered comments and ignored.
 
+Editing in Place
+----------------
+
+Open an encrypted file in your ``$EDITOR`` without writing a plaintext copy to disk:
+
+.. code-block:: bash
+
+   sops edit secrets.yaml
+
+SOPS decrypts to a temporary file, opens it in ``$EDITOR`` (falling back to ``vi``), re-encrypts on save, and removes the temporary file. The encrypted file on disk is updated atomically — no intermediate plaintext is left behind.
+
 Using .sops.yaml
 ----------------
 
@@ -39,6 +68,23 @@ A list of age recipients can be added to ``.sops.yaml`` to make encryption easie
        - age: >-
            age1s3cqcks5genc6ru8chl0hkkd04zmxvczsvdxq99ekffe4gmvjpzsedk23c,
            age1qe5lxzzeppw5k79vxn3872272sgy224g2nzqlzy3uljs84say3yqgvd0sw
+
+Rotating Recipients
+-------------------
+
+After updating ``.sops.yaml`` with new (or removed) age recipients, re-encrypt the data key without touching the underlying plaintext values:
+
+.. code-block:: bash
+
+   sops updatekeys secrets.yaml
+
+SOPS re-wraps the symmetric data key against the current set of recipients listed in ``.sops.yaml``. The encrypted values themselves are not re-encrypted — only the encrypted copy of the data key changes. Run ``sops updatekeys`` on every file whose recipients you want to update.
+
+To rotate all files in a directory in one pass:
+
+.. code-block:: bash
+
+   find . -name "*.enc.yaml" -exec sops updatekeys {} \;
 
 Encrypting with SSH Keys
 ------------------------

--- a/skills/sops/references/vault.rst
+++ b/skills/sops/references/vault.rst
@@ -49,14 +49,18 @@ The ``VAULT_ADDR``, ``VAULT_TOKEN``, and any TLS-related environment variables (
 Encrypting via CLI
 ------------------
 
-You can encrypt a file using the HashiCorp Vault transit engine directly from the CLI:
+You can encrypt a file using the HashiCorp Vault transit engine directly from the CLI. ``sops encrypt`` writes to **stdout** by default — redirect to a file or use ``-i`` to overwrite the source in place:
 
 .. code-block:: bash
 
    export VAULT_ADDR=http://127.0.0.1:8200
    export VAULT_TOKEN=... # Only needed if not already logged in
 
-   sops encrypt --hc-vault-transit $VAULT_ADDR/v1/sops/keys/firstkey vault_example.yml
+   # Redirect to a new file (recommended — keeps the original):
+   sops encrypt --hc-vault-transit $VAULT_ADDR/v1/sops/keys/firstkey vault_example.yml > vault_example.enc.yml
+
+   # Or encrypt in place:
+   sops encrypt -i --hc-vault-transit $VAULT_ADDR/v1/sops/keys/firstkey vault_example.yml
 
 Using .sops.yaml
 ----------------

--- a/skills/sops/references/vault.rst
+++ b/skills/sops/references/vault.rst
@@ -18,6 +18,34 @@ First, ensure you have a transit engine enabled in Vault. It is suggested to cre
    vault write sops/keys/secondkey type=rsa-2048
    vault write sops/keys/thirdkey type=chacha20-poly1305
 
+Authentication
+--------------
+
+SOPS uses the standard Vault client libraries, so it honours the same authentication mechanisms as the ``vault`` CLI. Both encrypt **and** decrypt operations require a reachable Vault instance with a valid credential.
+
+**Token-based auth (most common):**
+
+.. code-block:: bash
+
+   export VAULT_ADDR=http://vault.example.com:8200
+   export VAULT_TOKEN=s.xxxxxxxxxxxx
+
+If ``VAULT_TOKEN`` is not set, the Vault client falls back to the token stored in ``~/.vault-token`` (written by ``vault login``).
+
+**AppRole auth:**
+
+.. code-block:: bash
+
+   # Obtain a token from AppRole credentials
+   vault write auth/approle/login \
+     role_id=<ROLE_ID> \
+     secret_id=<SECRET_ID>
+
+   # Export the client_token from the response
+   export VAULT_TOKEN=<client_token>
+
+The ``VAULT_ADDR``, ``VAULT_TOKEN``, and any TLS-related environment variables (``VAULT_CACERT``, ``VAULT_SKIP_VERIFY``) must be available at **both** encrypt and decrypt time — not just when the file is first created.
+
 Encrypting via CLI
 ------------------
 
@@ -48,3 +76,22 @@ Then you can encrypt your target file simply, since SOPS will apply the correct 
 .. code-block:: bash
 
    sops encrypt --verbose prod/raw.yaml > prod/encrypted.yaml
+
+Rotating Keys
+-------------
+
+After changing recipients in ``.sops.yaml``, re-encrypt the data key with the current Vault transit key:
+
+.. code-block:: bash
+
+   sops updatekeys prod/encrypted.yaml
+
+This re-wraps the symmetric data key against the new Vault transit URI without re-encrypting the underlying values.
+
+**Rotating the Vault transit key itself** (cryptographic rotation) is a separate operation performed in Vault:
+
+.. code-block:: bash
+
+   vault write -f sops/keys/firstkey/rotate
+
+After a Vault key rotation, Vault uses the new key version for new encrypt operations but can still decrypt data encrypted with older versions (controlled by ``min_decryption_version``). To clean up old key versions and enforce a minimum version, see the `Vault Transit Secrets Engine documentation <https://developer.hashicorp.com/vault/docs/secrets/transit>`_ — do not set ``min_decryption_version`` higher than the version used to encrypt your oldest file without first running ``sops updatekeys`` on all affected files.


### PR DESCRIPTION
## Summary

Enriches the existing `sops` skill so it is ready to merge.

### Changes

| File | What changed |
|---|---|
| `skills/sops/SKILL.md` | Pushy description (676 bytes), `compatibility:` field, Quick Reference table, key-gen section, `.sops.yaml` workflow, rotation note, 7-item Gotchas section (105 lines, well under 500) |
| `skills/sops/references/age.rst` | Added: Generating a Key, Editing in Place, Rotating Recipients subsections |
| `skills/sops/references/vault.rst` | Added: Authentication (token/AppRole/env), Rotating Keys subsections |
| `docs/skill-creation/skills-registry.mdx` | `sops` row inserted alphabetically between `skill-review` and `starrocks` |
| `.changes/unreleased/Added-20260420-sops-skill.yaml` | Changie fragment (Added, 16 words, present tense, backtick-delimited) |

### Verification

- `asctl repo-check` exits 0, 52 skills validated (sops included)
- RST files render without structural errors
- Description: 676 bytes (< 1024 limit)
- SKILL.md: 105 lines (< 500 limit)
- Changie fragment: correct kind, body, slug