### PR TITLE
Canonicalize agent docs to AGENTS.md

### DIFF
--- a/.changes/unreleased/Added-20260421-agents-md-migration.yaml
+++ b/.changes/unreleased/Added-20260421-agents-md-migration.yaml
@@ -1,0 +1,2 @@
+kind: Added
+body: Add AGENTS.md and symlink CLAUDE.md and GEMINI.md for AI agent onboarding.

--- a/.changes/unreleased/Added-20260421-agents-md.yaml
+++ b/.changes/unreleased/Added-20260421-agents-md.yaml
@@ -1,0 +1,2 @@
+kind: Added
+body: "Seed AGENTS.md for AI agent onboarding and set CLAUDE.md/GEMINI.md as symlinks"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,35 +1,44 @@
 # AGENTS.md
 
-Agent guidance for this repository. Use this alongside the README for project context specific to coding agents.
+Agent guidance for this repository. Use this alongside the README and CONTRIBUTING.md for full project context and contributor workflows.
 
 ## Setup commands
 
 ```bash
 pixi install
+lefthook install
 ```
 
 ## Build, test, lint
 
 ```bash
-pixi run format
-pixi run lint
-pixi run test
-pixi run typecheck
-pixi run validate-skills
-cd skills/pi-rpc/scripts && make build test lint
-cd tools/asctl && make build test lint
-cd skills/jules/scripts && make build test lint
+pixi run -e default format
+pixi run -e default lint
+pixi run -e default test
+pixi run -e default typecheck
+pixi run -e default validate-skills
+cd skills/pi-rpc/scripts && make build && make test && make lint
+cd tools/asctl && go build ./... && go test -race -count=1 ./... && go vet ./...
+cd skills/jules/scripts && make build && make test && make lint
 ```
 
 ## Testing instructions
 
-The file-format skills (`csv`, `docx`, `xlsx`, `pdf`) each have an isolated pixi environment:
+The file-format skills (`csv`, `docx`, `xlsx`, `pdf`) each have an isolated pixi environment. Run that skill's `test`, `lint`, and `typecheck` tasks directly:
 
 ```bash
 pixi run -e csv test
+pixi run -e csv lint
+pixi run -e csv typecheck
 pixi run -e docx test
+pixi run -e docx lint
+pixi run -e docx typecheck
 pixi run -e xlsx test
+pixi run -e xlsx lint
+pixi run -e xlsx typecheck
 pixi run -e pdf test
+pixi run -e pdf lint
+pixi run -e pdf typecheck
 ```
 
 ## Code style

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# AGENTS.md
+
+Agent guidance for this repository. Use this alongside the README for project context specific to coding agents.
+
+## Setup commands
+
+```bash
+pixi install
+```
+
+## Build, test, lint
+
+```bash
+pixi run format
+pixi run lint
+pixi run test
+pixi run typecheck
+pixi run validate-skills
+cd skills/pi-rpc/scripts && make build test lint
+cd tools/asctl && make build test lint
+cd skills/jules/scripts && make build test lint
+```
+
+## Testing instructions
+
+The file-format skills (`csv`, `docx`, `xlsx`, `pdf`) each have an isolated pixi environment:
+
+```bash
+pixi run -e csv test
+pixi run -e docx test
+pixi run -e xlsx test
+pixi run -e pdf test
+```
+
+## Code style
+
+Formatted by ruff; run `pixi run format` before committing. Go code uses `gofmt`.
+
+## PR instructions
+
+Add a changie fragment before merge: `changie new`.
+Pre-commit / pre-push hooks run via lefthook. Run `lefthook install` once.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Canonicalize agent docs to AGENTS.md

Adopts the [agents.md](https://agents.md) convention fleet-wide in nq-rdl:
`AGENTS.md` is the source of truth; `CLAUDE.md` and `GEMINI.md` are symlinks to it.

### Changes
- Seeded `AGENTS.md` for AI agent onboarding. Detected repo tooling (`pixi`, `go.work`, `make`, `lefthook`, `changie`, `ruff`, `gofmt`) and populated setup, build/test/lint, testing instructions, code style, and PR instructions accordingly.
- Restructured headings into agents.md idiom — every existing instruction preserved.
- Symlinks: CLAUDE.md -> AGENTS.md, GEMINI.md -> AGENTS.md (git mode 120000).

### Verify locally
```bash
readlink CLAUDE.md   # AGENTS.md
readlink GEMINI.md   # AGENTS.md
diff <(cat CLAUDE.md) <(cat AGENTS.md)   # no diff
```

Part of the nq-rdl fleet migration.

---
*PR created automatically by Jules for task [7550921660722991258](https://jules.google.com/task/7550921660722991258) started by @rudolfjs*