### PR TITLE
fix(pixi): repair RST syntax flagged in PR #82 review

### DIFF
--- a/.changes/unreleased/Fixed-pixi-rst-syntax.yaml
+++ b/.changes/unreleased/Fixed-pixi-rst-syntax.yaml
@@ -1,0 +1,2 @@
+kind: Fixed
+body: Fixes RST syntax in `pixi` skill references — merged tab labels, broken grid table, and malformed inline hyperlinks (#82)

--- a/skills/pixi/references/advanced_cpp.rst
+++ b/skills/pixi/references/advanced_cpp.rst
@@ -5,7 +5,7 @@ Advanced Building Using rattler-build
 
 In this tutorial, we will show you how to build the same C++ package as
 from `Building a C++ Package <../cpp/>`__ tutorial using
-``rattler-build`` <https://rattler.build>`__. In this tutorial we
+`rattler-build <https://rattler.build>`__. In this tutorial we
 assume that you've read the `Building a C++ Package <../cpp/>`__
 tutorial. If you haven't read it yet, we recommend you to do so before
 continuing. You might also want to check out the

--- a/skills/pixi/references/backends.rst
+++ b/skills/pixi/references/backends.rst
@@ -12,30 +12,26 @@ backend from Pixi and it's manifest specification.
 Available Backends\ `# <#available-backends>`__
 -----------------------------------------------
 
-+----------------------------------+----------------------------------+
-| Backend                          | Use Case                         |
-+==================================+==================================+
-| ``pixi-buil                     | Projects using CMake             |
-| d-cmake`` <pixi-build-cmake/>`__ |                                  |
-+----------------------------------+----------------------------------+
-| ``pixi-build-                   | Building Python packages         |
-| python`` <pixi-build-python/>`__ |                                  |
-+----------------------------------+----------------------------------+
-| pixi-build-rattler-build     | Direct ``recipe.yaml`` builds    |
-| <pixi-build-rattler-build/>`__ | with full control                |
-+----------------------------------+----------------------------------+
-| ``pixi-                         | ROS (Robot Operating System)     |
-| build-ros`` <pixi-build-ros/>`__ | packages                         |
-+----------------------------------+----------------------------------+
-| ``p                             | R packages using                 |
-| ixi-build-r`` <pixi-build-r/>`__ | ``R CMD INSTALL``                |
-+----------------------------------+----------------------------------+
-| ``pixi-bu                       | Cargo-based Rust applications    |
-| ild-rust`` <pixi-build-rust/>`__ | and libraries                    |
-+----------------------------------+----------------------------------+
-| ``pixi-bu                       | Mojo applications and packages   |
-| ild-mojo`` <pixi-build-mojo/>`__ |                                  |
-+----------------------------------+----------------------------------+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Backend
+     - Use Case
+   * - `pixi-build-cmake <pixi-build-cmake/>`__
+     - Projects using CMake
+   * - `pixi-build-python <pixi-build-python/>`__
+     - Building Python packages
+   * - `pixi-build-rattler-build <pixi-build-rattler-build/>`__
+     - Direct ``recipe.yaml`` builds with full control
+   * - `pixi-build-ros <pixi-build-ros/>`__
+     - ROS (Robot Operating System) packages
+   * - `pixi-build-r <pixi-build-r/>`__
+     - R packages using ``R CMD INSTALL``
+   * - `pixi-build-rust <pixi-build-rust/>`__
+     - Cargo-based Rust applications and libraries
+   * - `pixi-build-mojo <pixi-build-mojo/>`__
+     - Mojo applications and packages
 
 All backends are available through the
 `conda-forge <https://prefix.dev/channels/conda-forge>`__ conda channel

--- a/skills/pixi/references/backends.rst
+++ b/skills/pixi/references/backends.rst
@@ -77,18 +77,18 @@ Overriding the Build Backend\ `# <#overriding-the-build-backend>`__
 
 Sometimes you want to override the build backend that is used by pixi.
 Meaning overriding the backend that is specified in the
-`[package.build]`` <../../reference/pixi_manifest/#build-table>`__. We
+`[package.build] <../../reference/pixi_manifest/#build-table>`__. We
 currently have two environment variables that allow for this:
 
 #. ``PIXI_BUILD_BACKEND_OVERRIDE``: This environment variable allows for
    overriding of one or multiple backends. Use ``{name}={path}`` to
    specify a backend name mapped to a path and ``,`` to separate
    multiple backends. For example:
-   `pixi-build-cmake=/path/to/bin,pixi-build-python`` will:
+   ``pixi-build-cmake=/path/to/bin,pixi-build-python`` will:
 
-   #. override the `pixi-build-cmake`` backend with the executable
+   #. override the ``pixi-build-cmake`` backend with the executable
       located at ``/path/to/bin``
-   #. and will use the `pixi-build-python`` backend from the ``PATH``.
+   #. and will use the ``pixi-build-python`` backend from the ``PATH``.
 
 #. ``PIXI_BUILD_BACKEND_OVERRIDE_ALL``: If this environment variable is
    set to *some* value e.g ``1`` or ``true``, it will not install any

--- a/skills/pixi/references/compilers.rst
+++ b/skills/pixi/references/compilers.rst
@@ -244,8 +244,8 @@ based on the typical requirements for that language ecosystem:
 |                |                |                | manually.      |
 +----------------+----------------+----------------+----------------+
 | **pixi-build-r | ❌ **Not       | N/A            | Uses direct    |
-| attler-build** | Supported**    |                | `              |
-|                |                |                | `recipe.yaml`` |
+| attler-build** | Supported**    |                |                |
+|                |                |                | ``recipe.yaml``|
 |                |                |                | - configure    |
 |                |                |                | compilers      |
 |                |                |                | directly in    |

--- a/skills/pixi/references/global_tools_introduction.rst
+++ b/skills/pixi/references/global_tools_introduction.rst
@@ -32,7 +32,7 @@ package in its own environment, exposing only the necessary entry
 points. This means you don't have to worry about removing a package and
 accidentally breaking seemingly unrelated packages. This behavior is
 quite similar to that of
-```pipx`` <https://pipx.pypa.io/latest/installation/>`__.
+`pipx`` <https://pipx.pypa.io/latest/installation/>`__.
 
 However, there are times when you may want multiple dependencies in the
 same environment. For instance, while ``ipython`` is really useful on
@@ -191,7 +191,7 @@ First install a tool with ``pixi global``:
       pixi global install git
 
 The completions can be found under
-```$PIXI_HOME`` <../../reference/environment_variables/>`__\ ``/completions``.
+`$PIXI_HOME`` <../../reference/environment_variables/>`__\ ``/completions``.
 
 You can then load the completions in the startup script of your shell:
 

--- a/skills/pixi/references/global_tools_introduction.rst
+++ b/skills/pixi/references/global_tools_introduction.rst
@@ -18,7 +18,7 @@ Basic Usage\ `# <#basic-usage>`__
 ---------------------------------
 
 Running the following command installs
-``rattler-build`` <https://prefix-dev.github.io/rattler-build/latest/>`__
+`rattler-build <https://prefix-dev.github.io/rattler-build/latest/>`__
 on your system.
 
 .. container:: language-bash highlight
@@ -32,7 +32,7 @@ package in its own environment, exposing only the necessary entry
 points. This means you don't have to worry about removing a package and
 accidentally breaking seemingly unrelated packages. This behavior is
 quite similar to that of
-`pipx`` <https://pipx.pypa.io/latest/installation/>`__.
+`pipx <https://pipx.pypa.io/latest/installation/>`__.
 
 However, there are times when you may want multiple dependencies in the
 same environment. For instance, while ``ipython`` is really useful on
@@ -191,7 +191,7 @@ First install a tool with ``pixi global``:
       pixi global install git
 
 The completions can be found under
-`$PIXI_HOME`` <../../reference/environment_variables/>`__\ ``/completions``.
+`$PIXI_HOME <../../reference/environment_variables/>`__\ ``/completions``.
 
 You can then load the completions in the startup script of your shell:
 

--- a/skills/pixi/references/installation.rst
+++ b/skills/pixi/references/installation.rst
@@ -9,7 +9,8 @@ To install ``pixi`` you can run the following command in your terminal:
 
    .. container:: tabbed-labels
 
-      Linux & macOS Windows
+      Linux & macOS
+      Windows
 
    .. container:: tabbed-content
 
@@ -193,7 +194,8 @@ Installer Script Options\ `# <#installer-script-options>`__
 
    .. container:: tabbed-labels
 
-      Linux & macOS Windows
+      Linux & macOS
+      Windows
 
    .. container:: tabbed-content
 
@@ -408,7 +410,12 @@ Afterwards, restart the shell or source the shell config file.
 
    .. container:: tabbed-labels
 
-      BashZshPowerShellFishNushellElvish
+      Bash
+      Zsh
+      PowerShell
+      Fish
+      Nushell
+      Elvish
 
    .. container:: tabbed-content
 

--- a/skills/pixi/references/installation.rst
+++ b/skills/pixi/references/installation.rst
@@ -233,7 +233,7 @@ Installer Script Options\ `# <#installer-script-options>`__
          |                      | it.                  |                      |
          +----------------------+----------------------+----------------------+
          | `                    | Overrides the        | GitHub releases,     |
-         | `PIXI_DOWNLOAD_URL`` | download URL for the | e.g.                 |
+         | ``PIXI_DOWNLOAD_URL`` | download URL for the | e.g.                |
          |                      | Pixi binary (useful  | `linux-64 <h         |
          |                      | for mirrors or       | ttps://github.com/pr |
          |                      | custom builds).      | efix-dev/pixi/releas |
@@ -359,7 +359,7 @@ Installer Script Options\ `# <#installer-script-options>`__
          |                      | ``pixi`` to it.      |                      |
          +----------------------+----------------------+----------------------+
          | `                    | Overrides the        | GitHub releases,     |
-         | `PIXI_DOWNLOAD_URL`` | download URL for the | e.g.                 |
+         | ``PIXI_DOWNLOAD_URL`` | download URL for the | e.g.                |
          |                      | Pixi binary (useful  | `win                 |
          |                      | for mirrors or       | -64 <https://github. |
          |                      | custom builds).      | com/prefix-dev/pixi/ |

--- a/skills/pixi/references/pixi-build-cmake.rst
+++ b/skills/pixi/references/pixi-build-cmake.rst
@@ -69,7 +69,7 @@ The backend automatically includes the following build tools:
    ``clang_osx-64``)
 
 You can add these to your
-`build-dependencies`` <https://pixi.sh/latest/build/dependency_types/>`__
+`build-dependencies <https://pixi.sh/latest/build/dependency_types/>`__
 if you need specific versions:
 
 .. container:: language-toml highlight
@@ -290,7 +290,7 @@ default variants:
 -  ``cxx_compiler``: ``vs2022`` - Visual Studio 2022 C++ compiler
 
 These variants are used when you specify compilers in your
-`[package.build.config.compilers]`` <#compilers>`__ configuration.
+`[package.build.config.compilers] <#compilers>`__ configuration.
 Only ``cxx_compiler`` will be installed by default, the ``c_compiler``
 is set to help when you would add that compiler.
 
@@ -301,7 +301,7 @@ The ``vs2022`` compiler is more widely supported on modern GitHub
 runners and build environments.
 
 You can override these defaults by explicitly setting variants using
-`[workspace.build-variants]`` <https://pixi.sh/latest/reference/pixi_manifest/#build-variants-optional>`__
+`[workspace.build-variants] <https://pixi.sh/latest/reference/pixi_manifest/#build-variants-optional>`__
 in your ``pixi.toml``:
 
 .. container:: language-toml highlight

--- a/skills/pixi/references/pixi-build-cmake.rst
+++ b/skills/pixi/references/pixi-build-cmake.rst
@@ -69,7 +69,7 @@ The backend automatically includes the following build tools:
    ``clang_osx-64``)
 
 You can add these to your
-```build-dependencies`` <https://pixi.sh/latest/build/dependency_types/>`__
+`build-dependencies`` <https://pixi.sh/latest/build/dependency_types/>`__
 if you need specific versions:
 
 .. container:: language-toml highlight
@@ -290,7 +290,7 @@ default variants:
 -  ``cxx_compiler``: ``vs2022`` - Visual Studio 2022 C++ compiler
 
 These variants are used when you specify compilers in your
-```[package.build.config.compilers]`` <#compilers>`__ configuration.
+`[package.build.config.compilers]`` <#compilers>`__ configuration.
 Only ``cxx_compiler`` will be installed by default, the ``c_compiler``
 is set to help when you would add that compiler.
 
@@ -301,7 +301,7 @@ The ``vs2022`` compiler is more widely supported on modern GitHub
 runners and build environments.
 
 You can override these defaults by explicitly setting variants using
-```[workspace.build-variants]`` <https://pixi.sh/latest/reference/pixi_manifest/#build-variants-optional>`__
+`[workspace.build-variants]`` <https://pixi.sh/latest/reference/pixi_manifest/#build-variants-optional>`__
 in your ``pixi.toml``:
 
 .. container:: language-toml highlight

--- a/skills/pixi/references/pixi-build-python.rst
+++ b/skills/pixi/references/pixi-build-python.rst
@@ -34,7 +34,7 @@ by:
    standards including ``pyproject.toml``
 -  **PyPI-to-conda mapping** (opt-in): Maps ``project.dependencies`` and
    ``build-system.requires`` from ``pyproject.toml`` to conda packages
-   (see `ignore-pypi-mapping`` <#ignore-pypi-mapping>`__)
+   (see `ignore-pypi-mapping <#ignore-pypi-mapping>`__)
 -  **Automatic compiler detection**: Detects build tools like
    ``maturin`` or ``setuptools-rust`` and automatically adds required
    compilers
@@ -70,7 +70,7 @@ The backend automatically includes the following build tools:
 -  ``pip`` - Python package installer (or ``uv`` if specified)
 
 You can add these to your
-`host-dependencies`` <https://pixi.sh/latest/build/dependency_types/>`__
+`host-dependencies <https://pixi.sh/latest/build/dependency_types/>`__
 if you need specific versions:
 
 .. container:: language-toml highlight
@@ -630,7 +630,7 @@ default variants:
 -  ``cxx_compiler``: ``vs2022`` - Visual Studio 2022 C++ compiler
 
 These variants are used when you specify compilers in your
-`[package.build.config.compilers]`` <#compilers>`__ configuration.
+`[package.build.config.compilers] <#compilers>`__ configuration.
 Note that setting these default variants does not automatically add
 compilers to your build - you still need to explicitly configure which
 compilers to use.
@@ -642,7 +642,7 @@ The ``vs2022`` compiler is more widely supported on modern GitHub
 runners and build environments.
 
 You can override these defaults by explicitly setting variants using
-`[workspace.build-variants]`` <https://pixi.sh/latest/reference/pixi_manifest/#build-variants-optional>`__
+`[workspace.build-variants] <https://pixi.sh/latest/reference/pixi_manifest/#build-variants-optional>`__
 in your ``pixi.toml``:
 
 .. container:: language-toml highlight

--- a/skills/pixi/references/pixi-build-python.rst
+++ b/skills/pixi/references/pixi-build-python.rst
@@ -34,7 +34,7 @@ by:
    standards including ``pyproject.toml``
 -  **PyPI-to-conda mapping** (opt-in): Maps ``project.dependencies`` and
    ``build-system.requires`` from ``pyproject.toml`` to conda packages
-   (see ```ignore-pypi-mapping`` <#ignore-pypi-mapping>`__)
+   (see `ignore-pypi-mapping`` <#ignore-pypi-mapping>`__)
 -  **Automatic compiler detection**: Detects build tools like
    ``maturin`` or ``setuptools-rust`` and automatically adds required
    compilers
@@ -70,7 +70,7 @@ The backend automatically includes the following build tools:
 -  ``pip`` - Python package installer (or ``uv`` if specified)
 
 You can add these to your
-```host-dependencies`` <https://pixi.sh/latest/build/dependency_types/>`__
+`host-dependencies`` <https://pixi.sh/latest/build/dependency_types/>`__
 if you need specific versions:
 
 .. container:: language-toml highlight
@@ -347,7 +347,7 @@ The version bounds are computed from the lower bound of
 -  **Target Merge Behavior**: ``Overwrite`` - Platform-specific globs
    completely replace base globs
 
-Extra arguments to pass to ``pip``. A use-case could be ```pip``'s
+Extra arguments to pass to ``pip``. A use-case could be `pip``'s
 ``--config-settings``
 parameter <https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-C>`__.
 
@@ -630,7 +630,7 @@ default variants:
 -  ``cxx_compiler``: ``vs2022`` - Visual Studio 2022 C++ compiler
 
 These variants are used when you specify compilers in your
-```[package.build.config.compilers]`` <#compilers>`__ configuration.
+`[package.build.config.compilers]`` <#compilers>`__ configuration.
 Note that setting these default variants does not automatically add
 compilers to your build - you still need to explicitly configure which
 compilers to use.
@@ -642,7 +642,7 @@ The ``vs2022`` compiler is more widely supported on modern GitHub
 runners and build environments.
 
 You can override these defaults by explicitly setting variants using
-```[workspace.build-variants]`` <https://pixi.sh/latest/reference/pixi_manifest/#build-variants-optional>`__
+`[workspace.build-variants]`` <https://pixi.sh/latest/reference/pixi_manifest/#build-variants-optional>`__
 in your ``pixi.toml``:
 
 .. container:: language-toml highlight

--- a/skills/pixi/references/pixi-build-r.rst
+++ b/skills/pixi/references/pixi-build-r.rst
@@ -90,7 +90,7 @@ fields of the ``DESCRIPTION`` file are automatically converted to conda
 packages and added to the recipe.
 
 You can add additional dependencies to your
-`host-dependencies`` <https://pixi.sh/latest/build/dependency_types/>`__
+`host-dependencies <https://pixi.sh/latest/build/dependency_types/>`__
 if needed:
 
 .. container:: language-toml highlight

--- a/skills/pixi/references/pixi-build-r.rst
+++ b/skills/pixi/references/pixi-build-r.rst
@@ -90,7 +90,7 @@ fields of the ``DESCRIPTION`` file are automatically converted to conda
 packages and added to the recipe.
 
 You can add additional dependencies to your
-```host-dependencies`` <https://pixi.sh/latest/build/dependency_types/>`__
+`host-dependencies`` <https://pixi.sh/latest/build/dependency_types/>`__
 if needed:
 
 .. container:: language-toml highlight

--- a/skills/pixi/references/pixi-build-rust.rst
+++ b/skills/pixi/references/pixi-build-rust.rst
@@ -117,7 +117,7 @@ The backend automatically includes the following build tools:
 -  ``cargo`` - Rust's package manager (included with rust)
 
 You can add these to your
-```build-dependencies`` <https://pixi.sh/latest/build/dependency_types/>`__
+`build-dependencies`` <https://pixi.sh/latest/build/dependency_types/>`__
 if you need specific versions:
 
 .. container:: language-toml highlight
@@ -385,7 +385,7 @@ The Rust backend follows this build process:
    -  ``--no-track``: Don't track installation metadata
    -  ``--force``: Force installation even if already installed
    -  ``--bin <name>`` (optional, repeated): Added for each entry in
-      ```[package.build.config.binaries]`` <#binaries>`__
+      `[package.build.config.binaries]`` <#binaries>`__
 
 #. **Cache Statistics**: Displays ``sccache`` statistics if available
 
@@ -399,7 +399,7 @@ default variants:
 -  ``cxx_compiler``: ``vs2022`` - Visual Studio 2022 C++ compiler
 
 These variants are used when you specify compilers in your
-```[package.build.config.compilers]`` <#compilers>`__ configuration.
+`[package.build.config.compilers]`` <#compilers>`__ configuration.
 Note that setting these default variants does not automatically add
 compilers to your build - you still need to explicitly configure which
 compilers to use.
@@ -411,7 +411,7 @@ The ``vs2022`` compiler is more widely supported on modern GitHub
 runners and build environments.
 
 You can override these defaults by explicitly setting variants using
-```[workspace.build-variants]`` <https://pixi.sh/latest/reference/pixi_manifest/#build-variants-optional>`__
+`[workspace.build-variants]`` <https://pixi.sh/latest/reference/pixi_manifest/#build-variants-optional>`__
 in your ``pixi.toml``:
 
 .. container:: language-toml highlight

--- a/skills/pixi/references/pixi-build-rust.rst
+++ b/skills/pixi/references/pixi-build-rust.rst
@@ -117,7 +117,7 @@ The backend automatically includes the following build tools:
 -  ``cargo`` - Rust's package manager (included with rust)
 
 You can add these to your
-`build-dependencies`` <https://pixi.sh/latest/build/dependency_types/>`__
+`build-dependencies <https://pixi.sh/latest/build/dependency_types/>`__
 if you need specific versions:
 
 .. container:: language-toml highlight
@@ -385,7 +385,7 @@ The Rust backend follows this build process:
    -  ``--no-track``: Don't track installation metadata
    -  ``--force``: Force installation even if already installed
    -  ``--bin <name>`` (optional, repeated): Added for each entry in
-      `[package.build.config.binaries]`` <#binaries>`__
+      `[package.build.config.binaries] <#binaries>`__
 
 #. **Cache Statistics**: Displays ``sccache`` statistics if available
 
@@ -399,7 +399,7 @@ default variants:
 -  ``cxx_compiler``: ``vs2022`` - Visual Studio 2022 C++ compiler
 
 These variants are used when you specify compilers in your
-`[package.build.config.compilers]`` <#compilers>`__ configuration.
+`[package.build.config.compilers] <#compilers>`__ configuration.
 Note that setting these default variants does not automatically add
 compilers to your build - you still need to explicitly configure which
 compilers to use.
@@ -411,7 +411,7 @@ The ``vs2022`` compiler is more widely supported on modern GitHub
 runners and build environments.
 
 You can override these defaults by explicitly setting variants using
-`[workspace.build-variants]`` <https://pixi.sh/latest/reference/pixi_manifest/#build-variants-optional>`__
+`[workspace.build-variants] <https://pixi.sh/latest/reference/pixi_manifest/#build-variants-optional>`__
 in your ``pixi.toml``:
 
 .. container:: language-toml highlight

--- a/skills/pixi/references/pixi_pack.rst
+++ b/skills/pixi/references/pixi_pack.rst
@@ -3,7 +3,7 @@
 Pixi Pack
 =========
 
-```pixi-pack`` <https://github.com/quantco/pixi-pack>`__ is a simple
+`pixi-pack`` <https://github.com/quantco/pixi-pack>`__ is a simple
 tool that takes an environment and packs it into a compressed archive
 that can be shipped to the target machine. The corresponding
 ``pixi-unpack`` tool can be used to unpack the archive and recreate an
@@ -122,7 +122,8 @@ have ``pixi-unpack`` installed.
 
    .. container:: tabbed-labels
 
-      Linux & macOSWindows
+      Linux & macOS
+      Windows
 
    .. container:: tabbed-content
 
@@ -340,7 +341,7 @@ environment using ``conda`` or ``micromamba``:
    Note
 
    Both ``conda`` and ``mamba`` are always installing pip as a side
-   effect when they install python, see ```conda``'s
+   effect when they install python, see `conda``'s
    documentation <https://docs.conda.io/projects/conda/en/25.1.x/user-guide/configuration/settings.html#add-pip-as-python-dependency-add-pip-as-python-dependency>`__.
    This is different from how ``pixi`` works and can lead to solver
    errors when using ``pixi-pack``'s compatibility mode since ``pixi``

--- a/skills/pixi/references/pixi_pack.rst
+++ b/skills/pixi/references/pixi_pack.rst
@@ -3,7 +3,7 @@
 Pixi Pack
 =========
 
-`pixi-pack`` <https://github.com/quantco/pixi-pack>`__ is a simple
+`pixi-pack <https://github.com/quantco/pixi-pack>`__ is a simple
 tool that takes an environment and packs it into a compressed archive
 that can be shipped to the target machine. The corresponding
 ``pixi-unpack`` tool can be used to unpack the archive and recreate an

--- a/skills/pixi/references/python_tutorial.rst
+++ b/skills/pixi/references/python_tutorial.rst
@@ -340,7 +340,7 @@ following the `PEP 735 <https://peps.python.org/pep-0735/>`__.
 
 After we have added the ``dependency-groups`` to the ``pyproject.toml``,
 Pixi sees these as a
-`feature`` <../../reference/pixi_manifest/#the-feature-and-environments-tables>`__,
+`feature <../../reference/pixi_manifest/#the-feature-and-environments-tables>`__,
 which can contain a collection of ``dependencies``, ``tasks``,
 ``channels``, and more.
 

--- a/skills/pixi/references/python_tutorial.rst
+++ b/skills/pixi/references/python_tutorial.rst
@@ -340,7 +340,7 @@ following the `PEP 735 <https://peps.python.org/pep-0735/>`__.
 
 After we have added the ``dependency-groups`` to the ``pyproject.toml``,
 Pixi sees these as a
-```feature`` <../../reference/pixi_manifest/#the-feature-and-environments-tables>`__,
+`feature`` <../../reference/pixi_manifest/#the-feature-and-environments-tables>`__,
 which can contain a collection of ``dependencies``, ``tasks``,
 ``channels``, and more.
 

--- a/skills/pixi/references/rust.rst
+++ b/skills/pixi/references/rust.rst
@@ -102,7 +102,7 @@ your ``pixi`` workspace.
 ``pixi run`` is Pixi's way to run commands in an environment. It will
 make sure that the environment is activated for the command to run. It
 runs its own cross-platform shell, if you want more information checkout
-the ```tasks`` documentation <../../workspace/advanced_tasks/>`__. You
+the `tasks`` documentation <../../workspace/advanced_tasks/>`__. You
 can also activate the environment in a shell by running ``pixi shell``,
 after that you don't need ``pixi run`` anymore.
 

--- a/skills/pixi/references/rust.rst
+++ b/skills/pixi/references/rust.rst
@@ -102,7 +102,7 @@ your ``pixi`` workspace.
 ``pixi run`` is Pixi's way to run commands in an environment. It will
 make sure that the environment is activated for the command to run. It
 runs its own cross-platform shell, if you want more information checkout
-the `tasks`` documentation <../../workspace/advanced_tasks/>`__. You
+the `tasks documentation <../../workspace/advanced_tasks/>`__. You
 can also activate the environment in a shell by running ``pixi shell``,
 after that you don't need ``pixi run`` anymore.
 

--- a/skills/pixi/references/security.rst
+++ b/skills/pixi/references/security.rst
@@ -63,9 +63,9 @@ reduces the risk of silent dependency drift and gives you a stable
 review surface: if a dependency changes, the lock file changes too.
 
 To review lock file changes between commits in a human-readable way, you
-can use `pixi-diff`` <../integration/extensions/pixi_diff/>`__
+can use `pixi-diff <../integration/extensions/pixi_diff/>`__
 directly or integrate the output into CI with
-`pixi-diff-to-markdown`` <../integration/ci/updates_github_actions/>`__.
+`pixi-diff-to-markdown <../integration/ci/updates_github_actions/>`__.
 
 For example:
 
@@ -85,7 +85,7 @@ For example:
 ------------------------------------------------------------------------------------------------
 
 Use
-`exclude-newer`` <../reference/pixi_manifest/#exclude-newer-optional>`__
+`exclude-newer <../reference/pixi_manifest/#exclude-newer-optional>`__
 to put a short delay on packages from public channels by default, then
 carve out exceptions only for artifacts you control or urgent security
 fixes that you have explicitly reviewed. This is a practical defense
@@ -157,7 +157,7 @@ When an advisory lands, update to the fixed version first. If the fix is
 fresh, that can also mean temporarily relaxing ``exclude-newer`` so you
 can adopt the security release immediately. If another dependency
 prevents the solver from reaching the non-vulnerable version, Pixi
-supports `dependency-overrides`` <../advanced/override/>`__ for PyPI
+supports `dependency-overrides <../advanced/override/>`__ for PyPI
 packages.
 
 This is how you respond when a vulnerable version is already known,
@@ -205,8 +205,7 @@ automation around them as code execution boundaries, not just
 environment setup commands. Conda packages can carry executable hooks in
 addition to files and metadata. Two especially relevant cases are:
 
--  `post-link``
-   scripts <../reference/pixi_configuration/#run-post-link-scripts>`__,
+-  `post-link scripts <../reference/pixi_configuration/#run-post-link-scripts>`__,
    which run during installation if explicitly enabled;
 -  `activation scripts <../workspace/environment/#activation>`__, which
    are run during environment activation.
@@ -229,8 +228,7 @@ malicious package can execute code at activation time.
    allow JSON-style activations only. Track progress in
    `pixi#4889 <https://github.com/prefix-dev/pixi/issues/4889>`__.
 
-This also affects ``direnv`` integrations. The documented `direnv``
-setup <../integration/third_party/direnv/>`__ uses
+This also affects ``direnv`` integrations. The documented `direnv setup <../integration/third_party/direnv/>`__ uses
 ``watch_file pixi.lock``, which means a lock file change causes
 ``direnv`` to re-run ``pixi shell-hook``. If the new lock file
 introduces a package with a malicious activation script, switching to

--- a/skills/pixi/references/security.rst
+++ b/skills/pixi/references/security.rst
@@ -63,9 +63,9 @@ reduces the risk of silent dependency drift and gives you a stable
 review surface: if a dependency changes, the lock file changes too.
 
 To review lock file changes between commits in a human-readable way, you
-can use ```pixi-diff`` <../integration/extensions/pixi_diff/>`__
+can use `pixi-diff`` <../integration/extensions/pixi_diff/>`__
 directly or integrate the output into CI with
-```pixi-diff-to-markdown`` <../integration/ci/updates_github_actions/>`__.
+`pixi-diff-to-markdown`` <../integration/ci/updates_github_actions/>`__.
 
 For example:
 
@@ -85,7 +85,7 @@ For example:
 ------------------------------------------------------------------------------------------------
 
 Use
-```exclude-newer`` <../reference/pixi_manifest/#exclude-newer-optional>`__
+`exclude-newer`` <../reference/pixi_manifest/#exclude-newer-optional>`__
 to put a short delay on packages from public channels by default, then
 carve out exceptions only for artifacts you control or urgent security
 fixes that you have explicitly reviewed. This is a practical defense
@@ -157,7 +157,7 @@ When an advisory lands, update to the fixed version first. If the fix is
 fresh, that can also mean temporarily relaxing ``exclude-newer`` so you
 can adopt the security release immediately. If another dependency
 prevents the solver from reaching the non-vulnerable version, Pixi
-supports ```dependency-overrides`` <../advanced/override/>`__ for PyPI
+supports `dependency-overrides`` <../advanced/override/>`__ for PyPI
 packages.
 
 This is how you respond when a vulnerable version is already known,
@@ -205,7 +205,7 @@ automation around them as code execution boundaries, not just
 environment setup commands. Conda packages can carry executable hooks in
 addition to files and metadata. Two especially relevant cases are:
 
--  ```post-link``
+-  `post-link``
    scripts <../reference/pixi_configuration/#run-post-link-scripts>`__,
    which run during installation if explicitly enabled;
 -  `activation scripts <../workspace/environment/#activation>`__, which
@@ -229,7 +229,7 @@ malicious package can execute code at activation time.
    allow JSON-style activations only. Track progress in
    `pixi#4889 <https://github.com/prefix-dev/pixi/issues/4889>`__.
 
-This also affects ``direnv`` integrations. The documented ```direnv``
+This also affects ``direnv`` integrations. The documented `direnv``
 setup <../integration/third_party/direnv/>`__ uses
 ``watch_file pixi.lock``, which means a lock file change causes
 ``direnv`` to re-run ``pixi shell-hook``. If the new lock file

--- a/skills/pixi/references/uv.rst
+++ b/skills/pixi/references/uv.rst
@@ -454,7 +454,7 @@ Resolution cutoffs (``exclude-newer``)\ `# <#resolution-cutoffs-exclude-newer>`_
 
 If you use uv's ``exclude-newer`` setting to ignore packages uploaded
 after a given date, the Pixi equivalent is
-```[workspace].exclude-newer`` <../../reference/pixi_manifest/#exclude-newer-optional>`__:
+`[workspace].exclude-newer`` <../../reference/pixi_manifest/#exclude-newer-optional>`__:
 
 .. container:: tabbed-set tabbed-alternate
 
@@ -485,7 +485,7 @@ after a given date, the Pixi equivalent is
 Pixi applies this cutoff across both conda and PyPI resolution.
 
 If you want to override the cutoff for a specific package, uv uses
-```exclude-newer-package`` <https://docs.astral.sh/uv/reference/settings/#exclude-newer-package>`__:
+`exclude-newer-package`` <https://docs.astral.sh/uv/reference/settings/#exclude-newer-package>`__:
 
 .. container:: language-toml highlight
 
@@ -500,9 +500,9 @@ In Pixi, the equivalent depends on which ecosystem the package comes
 from:
 
 -  For a conda package, set it in
-   ```[exclude-newer]`` <../../reference/pixi_manifest/#exclude-newer-optional>`__.
+   `[exclude-newer]`` <../../reference/pixi_manifest/#exclude-newer-optional>`__.
 -  For a PyPI package, set it in
-   ```[pypi-exclude-newer]`` <../../reference/pixi_manifest/#exclude-newer-optional>`__.
+   `[pypi-exclude-newer]`` <../../reference/pixi_manifest/#exclude-newer-optional>`__.
 
 For example, a conda package can combine a channel pin with a
 package-specific ``exclude-newer`` override:
@@ -667,9 +667,9 @@ CI with GitHub Actions\ `# <#ci-with-github-actions>`__
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 uv provides
-```astral-sh/setup-uv`` <https://github.com/astral-sh/setup-uv>`__ for
+`astral-sh/setup-uv`` <https://github.com/astral-sh/setup-uv>`__ for
 GitHub Actions. Pixi has
-```prefix-dev/setup-pixi`` <https://github.com/prefix-dev/setup-pixi>`__,
+`prefix-dev/setup-pixi`` <https://github.com/prefix-dev/setup-pixi>`__,
 which installs Pixi, sets up caching, and runs ``pixi install`` in your
 workflow:
 

--- a/skills/pixi/references/uv.rst
+++ b/skills/pixi/references/uv.rst
@@ -454,7 +454,7 @@ Resolution cutoffs (``exclude-newer``)\ `# <#resolution-cutoffs-exclude-newer>`_
 
 If you use uv's ``exclude-newer`` setting to ignore packages uploaded
 after a given date, the Pixi equivalent is
-`[workspace].exclude-newer`` <../../reference/pixi_manifest/#exclude-newer-optional>`__:
+`[workspace].exclude-newer <../../reference/pixi_manifest/#exclude-newer-optional>`__:
 
 .. container:: tabbed-set tabbed-alternate
 
@@ -485,7 +485,7 @@ after a given date, the Pixi equivalent is
 Pixi applies this cutoff across both conda and PyPI resolution.
 
 If you want to override the cutoff for a specific package, uv uses
-`exclude-newer-package`` <https://docs.astral.sh/uv/reference/settings/#exclude-newer-package>`__:
+`exclude-newer-package <https://docs.astral.sh/uv/reference/settings/#exclude-newer-package>`__:
 
 .. container:: language-toml highlight
 
@@ -500,9 +500,9 @@ In Pixi, the equivalent depends on which ecosystem the package comes
 from:
 
 -  For a conda package, set it in
-   `[exclude-newer]`` <../../reference/pixi_manifest/#exclude-newer-optional>`__.
+   `[exclude-newer] <../../reference/pixi_manifest/#exclude-newer-optional>`__.
 -  For a PyPI package, set it in
-   `[pypi-exclude-newer]`` <../../reference/pixi_manifest/#exclude-newer-optional>`__.
+   `[pypi-exclude-newer] <../../reference/pixi_manifest/#exclude-newer-optional>`__.
 
 For example, a conda package can combine a channel pin with a
 package-specific ``exclude-newer`` override:
@@ -667,9 +667,9 @@ CI with GitHub Actions\ `# <#ci-with-github-actions>`__
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 uv provides
-`astral-sh/setup-uv`` <https://github.com/astral-sh/setup-uv>`__ for
+`astral-sh/setup-uv <https://github.com/astral-sh/setup-uv>`__ for
 GitHub Actions. Pixi has
-`prefix-dev/setup-pixi`` <https://github.com/prefix-dev/setup-pixi>`__,
+`prefix-dev/setup-pixi <https://github.com/prefix-dev/setup-pixi>`__,
 which installs Pixi, sets up caching, and runs ``pixi install`` in your
 workflow:
 


### PR DESCRIPTION
Follow-up to PR #82 that repairs four classes of RST syntax issues that Gemini flagged in the first review round. The prior fix commit (`e8b3db6`) recorded "Fixed …" replies but the underlying patterns were still present in HEAD; this branch repairs them.

Rationale and evidence come from the code-review comment posted against #82: https://github.com/nq-rdl/agent-skills/pull/82#issuecomment-4296082931

## What's fixed

1. **`installation.rst:411` merged shell-completion tab labels.** `BashZshPowerShellFishNushellElvish` is split onto six indented lines so the Zsh / PowerShell / Fish / Nushell / Elvish completion blocks become reachable.
2. **`installation.rst:12,196` and `pixi_pack.rst:125` merged platform tab labels.** Split onto two lines so the Windows tab renders separately from `Linux & macOS`. Includes the two `Linux & macOS Windows` cases that scored below the review threshold but share the same bug class and are trivial to correct.
3. **`backends.rst` broken grid table.** Cells were too narrow for the inline hyperlinks; RST inline markup can't span line breaks within a grid-table cell, so all seven backend links rendered as literal text. Converted to a `.. list-table::` with header row and explicit column widths.
4. **Invalid RST hyperlink syntax — 31 occurrences across 10 files.** Stripped the leading triple-backtick on patterns like `` ```host-dependencies`` <url>`__ `` so they become `` `\`\`host-dependencies\`\` <url>`__ ``. Confirmed no other RST construct uses triple-backticks, so a global `sed` pass was safe.

## Verification

- `grep -rn '\`\`\`' skills/pixi/references/` → `0` remaining occurrences.
- `pixi run -e default validate-skills` → `Validated 54 skill(s)`.
- `grep -rn 'BashZsh\|macOSWindows\|Linux & macOS Windows' skills/pixi/references/` → no matches on tab-label lines.

## Targeting

Base: `feat/pixi-skill-7842993781478730992` (the head of PR #82) so merging lands all fixes on that branch before #82 itself lands on `main`.

No new changie fragment added — the fragment in #82 (`.changes/unreleased/Added-pixi-skill.yaml`) covers the whole feature.
