### PR TITLE
feat(duckdb): add vendored DuckDB skill bundle

### DIFF
--- a/.changes/unreleased/Added-duckdb-skill.yaml
+++ b/.changes/unreleased/Added-duckdb-skill.yaml
@@ -1,0 +1,2 @@
+kind: Added
+body: Add the vendored DuckDB skill bundle and a scheduled upstream drift check.

--- a/.github/workflows/duckdb-upstream-check.yml
+++ b/.github/workflows/duckdb-upstream-check.yml
@@ -1,0 +1,112 @@
+name: Check DuckDB Upstream
+
+on:
+  schedule:
+    - cron: "23 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: duckdb-upstream-check
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Load pinned DuckDB upstream metadata
+        id: pinned
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          data = json.loads(Path("skills/duckdb/upstream.json").read_text())
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              for key in ("repo", "ref", "commit"):
+                  fh.write(f"{key}={data[key]}\n")
+          PY
+
+      - name: Fetch latest upstream commit
+        id: upstream
+        run: |
+          latest=$(git ls-remote "${{ steps.pinned.outputs.repo }}" "${{ steps.pinned.outputs.ref }}" | cut -f1)
+          if [ -z "$latest" ]; then
+            echo "::error::Failed to resolve duckdb-skills upstream HEAD"
+            exit 1
+          fi
+          echo "commit=$latest" >> "$GITHUB_OUTPUT"
+
+      - name: Open or close tracking issue
+        uses: actions/github-script@v7
+        env:
+          PINNED_COMMIT: ${{ steps.pinned.outputs.commit }}
+          LATEST_COMMIT: ${{ steps.upstream.outputs.commit }}
+          UPSTREAM_REPO: ${{ steps.pinned.outputs.repo }}
+        with:
+          script: |
+            const title = 'duckdb-skills upstream update available';
+            const pinned = process.env.PINNED_COMMIT;
+            const latest = process.env.LATEST_COMMIT;
+            const repoUrl = process.env.UPSTREAM_REPO.replace(/\.git$/, '');
+            const compareUrl = `${repoUrl}/compare/${pinned}...${latest}`;
+            const {owner, repo} = context.repo;
+
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100,
+            });
+            const existing = issues.find((issue) => issue.title === title);
+
+            if (pinned === latest) {
+              core.info(`DuckDB upstream unchanged at ${pinned}.`);
+              if (existing) {
+                await github.rest.issues.createComment({
+                  owner,
+                  repo,
+                  issue_number: existing.number,
+                  body: `Pinned DuckDB upstream commit now matches \`${latest}\`. Closing this tracker.`,
+                });
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number: existing.number,
+                  state: 'closed',
+                });
+              }
+              return;
+            }
+
+            const body = [
+              'DuckDB upstream changed since the last pinned sync.',
+              '',
+              `- Pinned commit: \`${pinned}\``,
+              `- Latest commit: \`${latest}\``,
+              `- Compare: ${compareUrl}`,
+              '',
+              'Review the upstream diff and update the vendored content under `skills/duckdb/` if the new behavior should be adopted.',
+            ].join('\n');
+
+            if (existing) {
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number: existing.number,
+                body,
+              });
+            } else {
+              await github.rest.issues.create({
+                owner,
+                repo,
+                title,
+                body,
+              });
+            }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ pre-push tests automatically.
 
 ```
 agent-skills/
-├── skills/                   # The skills themselves (52 of them)
+├── skills/                   # The skills themselves
 │   ├── pi-rpc/               # Each skill = a directory with SKILL.md
 │   │   ├── SKILL.md          # Frontmatter + body; the public contract
 │   │   └── scripts/          # Per-skill runtime code (Go here: pi-server, pi-cli, pi-mcp)

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -30,6 +30,7 @@ RDL uses [nq-rdl/agent-extensions](https://github.com/nq-rdl/agent-extensions) t
 
 | Skill | Description |
 |-------|-------------|
+| [duckdb](../skills/duckdb/) | DuckDB CLI workflows bundled under one skill: attach databases, query files and tables, convert formats, inspect object storage, search docs, and run spatial analysis. |
 | [starrocks](../skills/starrocks/) | StarRocks analytical data warehouse — SQL authoring, table design, partitioning, materialized views, external catalogs. |
 
 ### Developer Workflow

--- a/skills/duckdb/SKILL.md
+++ b/skills/duckdb/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: duckdb
+description: >-
+  Work with DuckDB from the CLI: install or update DuckDB and extensions,
+  attach database files, query local or remote data, convert formats, explore
+  object storage, search DuckDB docs, run spatial analysis, and inspect prior
+  session logs stored as JSONL. Use when the user mentions DuckDB, wants SQL
+  over files or buckets, needs DuckDB-backed conversion or profiling, or asks
+  for DuckDB extension help.
+---
+
+# DuckDB
+
+Use this skill as a dispatcher. Start here, choose the closest DuckDB workflow, then open that nested `SKILL.md` before doing substantial work.
+
+## Choose A Workflow
+
+| Need | Read next |
+| --- | --- |
+| Attach a `.duckdb` database file and keep it available for repeated queries | [attach-db/SKILL.md](attach-db/SKILL.md) |
+| Run SQL or turn a natural-language request into DuckDB SQL | [query/SKILL.md](query/SKILL.md) |
+| Inspect a local file, remote URL, schema, or sample rows | [read-file/SKILL.md](read-file/SKILL.md) |
+| Convert data between CSV, Parquet, JSON, Excel, or spatial formats | [convert-file/SKILL.md](convert-file/SKILL.md) |
+| Install or update DuckDB and DuckDB extensions | [install-duckdb/SKILL.md](install-duckdb/SKILL.md) |
+| Explore S3, R2, GCS, MinIO, or compatible object storage | [s3-explore/SKILL.md](s3-explore/SKILL.md) |
+| Answer spatial questions or work with Overture Maps and spatial files | [spatial/SKILL.md](spatial/SKILL.md) |
+| Search DuckDB or DuckLake docs using a local cached index | [duckdb-docs/SKILL.md](duckdb-docs/SKILL.md) |
+| Search prior session logs stored as JSONL | [read-memories/SKILL.md](read-memories/SKILL.md) |
+
+## Shared Conventions
+
+- Prefer direct `duckdb` CLI invocations over ad-hoc helper scripts when one SQL call is enough.
+- Reuse the shared DuckDB session state file when attaching databases. The supported locations are `.duckdb-skills/state.sql` in the project or `~/.duckdb-skills/<project-id>/state.sql`.
+- Append to `state.sql`; never overwrite it. Other workflows may already have written macros, secrets, extension loads, or `ATTACH` statements there.
+- In ad-hoc file mode, restrict DuckDB to explicit file paths and disable external access unless the user asked for remote data.
+- Read only the nested references needed for the active workflow. The detailed procedures live in the subdirectories, not in this top-level dispatcher.

--- a/skills/duckdb/attach-db/SKILL.md
+++ b/skills/duckdb/attach-db/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: attach-db
+description: Attach a DuckDB database file, inspect its tables and schema, and append an `ATTACH` entry to the shared DuckDB state file used by the sibling query workflow. Use when the user wants to open a `.duckdb` file or make a database available for repeated DuckDB queries.
+---
+
+# Attach DB
+
+Treat the user's database path as the target database.
+
+Follow these steps in order, stopping and reporting clearly if any step fails.
+
+**State file convention**: All DuckDB subworkflows share one `state.sql` file per project. Once resolved, any workflow can reuse it with `duckdb -init "$STATE_DIR/state.sql" -c "<QUERY>"`.
+
+## Step 1 - Resolve The Database Path
+
+If the user gave a relative path, resolve it against `$PWD` to get an absolute path (`RESOLVED_PATH`).
+
+```bash
+RESOLVED_PATH="$(cd "$(dirname "$0")" 2>/dev/null && pwd)/$(basename "$0")"
+```
+
+Check the file exists:
+
+```bash
+test -f "$RESOLVED_PATH"
+```
+
+- **File exists** -> continue to Step 2.
+- **File not found** -> ask the user if they want to create a new empty database. DuckDB creates the file on first write. If yes, continue. If no, stop.
+
+## Step 2 - Check DuckDB Is Installed
+
+```bash
+command -v duckdb
+```
+
+If not found, open [../install-duckdb/SKILL.md](../install-duckdb/SKILL.md), follow it to install DuckDB, then continue.
+
+## Step 3 - Validate The Database
+
+```bash
+duckdb "$RESOLVED_PATH" -c "PRAGMA version;"
+```
+
+- **Success** -> continue.
+- **Failure** -> report the error clearly, for example a corrupt file or a non-DuckDB database, and stop.
+
+## Step 4 - Explore The Schema
+
+First, list all tables:
+
+```bash
+duckdb "$RESOLVED_PATH" -csv -c "
+SELECT table_name, estimated_size
+FROM duckdb_tables()
+ORDER BY table_name;
+"
+```
+
+If the database has **no tables**, note that it is empty and skip to Step 5.
+
+For each table discovered, up to 20 tables, run:
+
+```bash
+duckdb "$RESOLVED_PATH" -csv -c "
+DESCRIBE <table_name>;
+SELECT count() AS row_count FROM <table_name>;
+"
+```
+
+Collect the column definitions and row counts for the summary.
+
+## Step 5 - Resolve The State Directory
+
+Check whether a state file already exists in either location:
+
+```bash
+test -f .duckdb-skills/state.sql && STATE_DIR=".duckdb-skills"
+
+PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")"
+PROJECT_ID="$(echo "$PROJECT_ROOT" | tr '/' '-')"
+test -f "$HOME/.duckdb-skills/$PROJECT_ID/state.sql" && STATE_DIR="$HOME/.duckdb-skills/$PROJECT_ID"
+```
+
+If **neither exists**, ask the user:
+
+> Where should DuckDB session state live for this project?
+>
+> 1. **In the project directory** (`.duckdb-skills/state.sql`) so it is easy to inspect locally.
+> 2. **In the home directory** (`~/.duckdb-skills/<project-id>/state.sql`) so the project tree stays clean.
+
+Based on their choice:
+
+**Option 1:**
+
+```bash
+STATE_DIR=".duckdb-skills"
+mkdir -p "$STATE_DIR"
+```
+
+Then ask whether they want `.duckdb-skills/` added to `.gitignore`. If yes:
+
+```bash
+echo '.duckdb-skills/' >> .gitignore
+```
+
+**Option 2:**
+
+```bash
+PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")"
+PROJECT_ID="$(echo "$PROJECT_ROOT" | tr '/' '-')"
+STATE_DIR="$HOME/.duckdb-skills/$PROJECT_ID"
+mkdir -p "$STATE_DIR"
+```
+
+## Step 6 - Append To The State File
+
+`state.sql` is a shared, accumulative init file used by all DuckDB subworkflows. It may already contain macros, `LOAD` statements, secrets, or other `ATTACH` statements written by other workflows. **Never overwrite it**. Check for duplicates and append only when needed.
+
+Derive the database alias from the filename without extension, for example `my_data.duckdb` -> `my_data`. Check whether this `ATTACH` already exists:
+
+```bash
+grep -q "ATTACH.*RESOLVED_PATH" "$STATE_DIR/state.sql" 2>/dev/null
+```
+
+If it is not already present, append:
+
+```bash
+cat >> "$STATE_DIR/state.sql" <<'STATESQL'
+ATTACH IF NOT EXISTS 'RESOLVED_PATH' AS my_data;
+USE my_data;
+STATESQL
+```
+
+Replace `RESOLVED_PATH` and `my_data` with the actual values. If the alias would conflict with an existing one in the file, ask the user for a different alias.
+
+## Step 7 - Verify The State File Works
+
+```bash
+duckdb -init "$STATE_DIR/state.sql" -c "SHOW TABLES;"
+```
+
+If this fails, fix the state file and retry.
+
+## Step 8 - Report
+
+Summarize for the user:
+
+- **Database path**: the resolved absolute path
+- **Alias**: the database alias used in the state file
+- **State file**: the resolved `STATE_DIR/state.sql` path
+- **Tables**: name, column count, and row count for each table, or note that the database is empty
+- Confirm the database is now available to the sibling query workflow in [../query/SKILL.md](../query/SKILL.md)
+
+If the database is empty, suggest creating tables or importing data.

--- a/skills/duckdb/attach-db/SKILL.md
+++ b/skills/duckdb/attach-db/SKILL.md
@@ -13,10 +13,11 @@ Follow these steps in order, stopping and reporting clearly if any step fails.
 
 ## Step 1 - Resolve The Database Path
 
-If the user gave a relative path, resolve it against `$PWD` to get an absolute path (`RESOLVED_PATH`).
+Start by assigning the user-supplied database path to a shell variable such as `USER_DB_PATH`. If the user gave a relative path, resolve it against `$PWD` to get an absolute path (`RESOLVED_PATH`).
 
 ```bash
-RESOLVED_PATH="$(cd "$(dirname "$0")" 2>/dev/null && pwd)/$(basename "$0")"
+USER_DB_PATH="<USER_DB_PATH>"
+RESOLVED_PATH="$(cd "$(dirname "$USER_DB_PATH")" 2>/dev/null && pwd)/$(basename "$USER_DB_PATH")"
 ```
 
 Check the file exists:
@@ -117,22 +118,30 @@ mkdir -p "$STATE_DIR"
 
 `state.sql` is a shared, accumulative init file used by all DuckDB subworkflows. It may already contain macros, `LOAD` statements, secrets, or other `ATTACH` statements written by other workflows. **Never overwrite it**. Check for duplicates and append only when needed.
 
-Derive the database alias from the filename without extension, for example `my_data.duckdb` -> `my_data`. Check whether this `ATTACH` already exists:
+Derive the database alias from the filename without extension, for example `my_data.duckdb` -> `my_data`.
+
+Before embedding the path in SQL, escape any single quotes by doubling them:
 
 ```bash
-grep -q "ATTACH.*RESOLVED_PATH" "$STATE_DIR/state.sql" 2>/dev/null
+SQL_PATH=${RESOLVED_PATH//\'/\'\'}
+```
+
+Then check whether this `ATTACH` already exists:
+
+```bash
+grep -Fq "ATTACH IF NOT EXISTS '$SQL_PATH'" "$STATE_DIR/state.sql" 2>/dev/null
 ```
 
 If it is not already present, append:
 
 ```bash
 cat >> "$STATE_DIR/state.sql" <<'STATESQL'
-ATTACH IF NOT EXISTS 'RESOLVED_PATH' AS my_data;
+ATTACH IF NOT EXISTS 'SQL_PATH' AS my_data;
 USE my_data;
 STATESQL
 ```
 
-Replace `RESOLVED_PATH` and `my_data` with the actual values. If the alias would conflict with an existing one in the file, ask the user for a different alias.
+Replace `SQL_PATH` and `my_data` with the actual values. Use the escaped `SQL_PATH`, not the raw path, anywhere the path is inserted into SQL. If the alias would conflict with an existing one in the file, ask the user for a different alias.
 
 ## Step 7 - Verify The State File Works
 

--- a/skills/duckdb/convert-file/SKILL.md
+++ b/skills/duckdb/convert-file/SKILL.md
@@ -12,7 +12,8 @@ Treat the first user-supplied path as the input file. If the user supplied a sec
 **Input**: If the user gave a bare filename with no `/`, resolve it to a full path with:
 
 ```bash
-find "$PWD" -name "$0" -not -path '*/.git/*' 2>/dev/null | head -1
+INPUT_FILENAME="<INPUT_FILENAME>"
+find "$PWD" -name "$INPUT_FILENAME" -not -path '*/.git/*' 2>/dev/null | head -1
 ```
 
 **Output**: If the user supplied an explicit output path, use it. Otherwise default to the same stem as the input with a `.parquet` extension, for example `data.csv` -> `data.parquet`.

--- a/skills/duckdb/convert-file/SKILL.md
+++ b/skills/duckdb/convert-file/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: convert-file
+description: Convert data files between CSV, Parquet, JSON, Excel, GeoJSON, and related formats with DuckDB. Use when the user asks to convert a file, export a dataset, save results in another format, or write binary outputs such as Parquet or XLSX.
+---
+
+# Convert File
+
+Treat the first user-supplied path as the input file. If the user supplied a second path, treat it as the output file.
+
+## Step 1 - Resolve Input And Output
+
+**Input**: If the user gave a bare filename with no `/`, resolve it to a full path with:
+
+```bash
+find "$PWD" -name "$0" -not -path '*/.git/*' 2>/dev/null | head -1
+```
+
+**Output**: If the user supplied an explicit output path, use it. Otherwise default to the same stem as the input with a `.parquet` extension, for example `data.csv` -> `data.parquet`.
+
+Infer the output format from the output file extension:
+
+| Extension | Format clause |
+| --- | --- |
+| `.parquet`, `.pq` | default, no clause needed |
+| `.csv` | `(FORMAT csv, HEADER)` |
+| `.tsv` | `(FORMAT csv, HEADER, DELIMITER '\t')` |
+| `.json` | `(FORMAT json, ARRAY true)` |
+| `.jsonl`, `.ndjson` | `(FORMAT json, ARRAY false)` |
+| `.xlsx` | `(FORMAT xlsx)` and requires `INSTALL excel; LOAD excel;` |
+| `.geojson` | `(FORMAT GDAL, DRIVER 'GeoJSON')` and requires `LOAD spatial;` |
+| `.gpkg` | `(FORMAT GDAL, DRIVER 'GPKG')` and requires `LOAD spatial;` |
+| `.shp` | `(FORMAT GDAL, DRIVER 'ESRI Shapefile')` and requires `LOAD spatial;` |
+
+## Step 2 - Convert
+
+Run a single DuckDB command. Prepend extension loads as needed based on both the input and output formats.
+
+```bash
+duckdb -c "
+<EXTENSION_LOADS>
+COPY (FROM '<INPUT_PATH>') TO '<OUTPUT_PATH>' <FORMAT_CLAUSE>;
+"
+```
+
+For remote inputs such as `s3://` or `https://`, prepend the same protocol setup as the sibling [../read-file/SKILL.md](../read-file/SKILL.md) workflow:
+
+| Protocol | Prepend |
+| --- | --- |
+| `s3://` | `LOAD httpfs; CREATE SECRET (TYPE S3, PROVIDER credential_chain);` |
+| `gs://`, `gcs://` | `LOAD httpfs; CREATE SECRET (TYPE GCS, PROVIDER credential_chain);` |
+| `https://`, `http://` | `LOAD httpfs;` |
+
+If the user mentions partitioning, for example "partition by year", add `PARTITION_BY (col)` to the format clause. This only works with Parquet and CSV output.
+
+If the user mentions compression, for example "use zstd", add `CODEC 'zstd'` for Parquet output.
+
+## Step 3 - Report
+
+On success, report:
+
+- Input file and detected format
+- Output file, format, and size from `ls -lh`
+- Row count if it is quick to compute
+
+On failure:
+
+- **`duckdb: command not found`** -> open [../install-duckdb/SKILL.md](../install-duckdb/SKILL.md), install DuckDB, then retry
+- **Missing extension** -> install it and retry
+- **Input parse error** -> suggest checking the input format or using [../read-file/SKILL.md](../read-file/SKILL.md) first to inspect it

--- a/skills/duckdb/duckdb-docs/SKILL.md
+++ b/skills/duckdb/duckdb-docs/SKILL.md
@@ -1,0 +1,140 @@
+---
+name: duckdb-docs
+description: Search DuckDB and DuckLake documentation and blog posts with a locally cached full-text index. Use when the user asks how DuckDB works, needs official syntax or behavior details, or wants DuckLake-specific documentation.
+---
+
+# DuckDB Docs
+
+Treat the user's request as the documentation query.
+
+Follow these steps in order.
+
+## Step 1 - Check DuckDB Is Installed
+
+```bash
+command -v duckdb
+```
+
+If not found, open [../install-duckdb/SKILL.md](../install-duckdb/SKILL.md), follow it to install DuckDB, then continue.
+
+## Step 2 - Ensure Required Extensions Are Installed
+
+```bash
+duckdb :memory: -c "INSTALL httpfs; INSTALL fts;"
+```
+
+If this fails, report the error and stop.
+
+## Step 3 - Choose The Data Source And Extract Search Terms
+
+There are two search indexes available:
+
+| Index | Remote URL | Local cache filename | Versions | Use when |
+| --- | --- | --- | --- | --- |
+| **DuckDB docs + blog** | `https://duckdb.org/data/docs-search.duckdb` | `duckdb-docs.duckdb` | `lts`, `current`, `blog` | Default for DuckDB questions |
+| **DuckLake docs** | `https://ducklake.select/data/docs-search.duckdb` | `ducklake-docs.duckdb` | `stable`, `preview` | Queries that mention DuckLake, catalogs, or DuckLake-specific features |
+
+Both indexes share the same schema:
+
+| Column | Type | Description |
+| --- | --- | --- |
+| `chunk_id` | `VARCHAR` | For example, `stable/sql/functions/numeric#absx` |
+| `page_title` | `VARCHAR` | Page title from front matter |
+| `section` | `VARCHAR` | Section heading, or null for page intros |
+| `breadcrumb` | `VARCHAR` | For example, `SQL > Functions > Numeric` |
+| `url` | `VARCHAR` | URL path with anchor |
+| `version` | `VARCHAR` | One of the versions above |
+| `text` | `TEXT` | Full markdown of the chunk |
+
+By default, search DuckDB docs and filter to `version = 'lts'`. Use different versions when:
+
+- The user explicitly asks about `current` or nightly features -> `version = 'current'`
+- The user asks about a blog post or wants background and motivation -> `version = 'blog'`
+- The user asks about DuckLake -> search the DuckLake index with `version = 'stable'`
+- When unsure, omit the version filter to search across all versions
+
+If the input is a natural-language question, extract the key technical terms, nouns, function names, and SQL keywords to form a compact BM25 query string. Drop stop words such as "how", "do", "I", and "the".
+
+If the input is already a function name or technical term, for example `arg_max` or `GROUP BY ALL`, use it as-is.
+
+Use the extracted terms as `SEARCH_QUERY` in the next step.
+
+## Step 4 - Ensure The Local Cache Is Fresh
+
+The cache lives at `$HOME/.duckdb/docs/CACHE_FILENAME`, where `CACHE_FILENAME` is `duckdb-docs.duckdb` or `ducklake-docs.duckdb` based on Step 3.
+
+First, ensure the directory exists:
+
+```bash
+mkdir -p "$HOME/.duckdb/docs"
+```
+
+Then check whether the cache file exists and is fresh, meaning no more than two days old:
+
+```bash
+CACHE_FILE="$HOME/.duckdb/docs/CACHE_FILENAME"
+if [ -f "$CACHE_FILE" ]; then
+    MTIME=$(stat -f %m "$CACHE_FILE" 2>/dev/null || stat -c %Y "$CACHE_FILE")
+    CACHE_AGE_DAYS=$(( ( $(date +%s) - MTIME ) / 86400 ))
+else
+    CACHE_AGE_DAYS=999
+fi
+echo "Cache age: $CACHE_AGE_DAYS days"
+```
+
+If `CACHE_AGE_DAYS <= 2`, skip to Step 5.
+
+Otherwise fetch the index:
+
+```bash
+duckdb -c "
+LOAD httpfs;
+LOAD fts;
+ATTACH 'REMOTE_URL' AS remote (READ_ONLY);
+ATTACH '$HOME/.duckdb/docs/CACHE_FILENAME.tmp' AS tmp;
+COPY FROM DATABASE remote TO tmp;
+" && mv "$HOME/.duckdb/docs/CACHE_FILENAME.tmp" "$HOME/.duckdb/docs/CACHE_FILENAME"
+```
+
+Replace `REMOTE_URL` and `CACHE_FILENAME` based on Step 3. If the fetch fails, report the error and stop.
+
+## Step 5 - Search The Docs
+
+```bash
+duckdb "$HOME/.duckdb/docs/CACHE_FILENAME" -readonly -json -c "
+LOAD fts;
+SELECT
+    chunk_id, page_title, section, breadcrumb, url, version, text,
+    fts_main_docs_chunks.match_bm25(chunk_id, 'SEARCH_QUERY') AS score
+FROM docs_chunks
+WHERE score IS NOT NULL
+  AND version = 'VERSION'
+ORDER BY score DESC
+LIMIT 8;
+"
+```
+
+Replace `CACHE_FILENAME`, `SEARCH_QUERY`, and `VERSION` based on Step 3. Remove the `AND version = 'VERSION'` line when searching across all versions.
+
+If the user's question could benefit from both DuckDB docs and blog results, run two queries or omit the version filter entirely.
+
+## Step 6 - Handle Errors
+
+- **Extension not installed** (`httpfs` or `fts` not found): run `duckdb :memory: -c "INSTALL httpfs; INSTALL fts;"` and retry.
+- **`ATTACH` fails or the network is unreachable**: explain that the docs index is unavailable and suggest checking network access. The DuckDB index is hosted at `https://duckdb.org/data/docs-search.duckdb` and the DuckLake index at `https://ducklake.select/data/docs-search.duckdb`.
+- **No results**: broaden the query by dropping the least specific term, or retry with a single-word query. If there are still no results, say so and point the user to `https://duckdb.org/docs` or `https://ducklake.select/docs`.
+
+## Step 7 - Present Results
+
+For each result chunk, ordered by descending score, format as:
+
+```text
+### {section} - {page_title}
+{url}
+
+{text}
+
+---
+```
+
+After presenting the chunks, synthesize a concise answer to the user's original question based on the retrieved documentation. If the chunks directly answer the question, lead with the answer before showing the sources.

--- a/skills/duckdb/install-duckdb/SKILL.md
+++ b/skills/duckdb/install-duckdb/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: install-duckdb
+description: Install or update DuckDB extensions, or update the DuckDB CLI itself when needed. Use when DuckDB is missing, an extension needs to be installed or refreshed, or another DuckDB workflow reports a missing extension.
+---
+
+# Install DuckDB
+
+Treat each requested argument as either `name` or `name@repo`. Use `--update` to switch from install mode to update mode.
+
+Each extension argument has the form `name` or `name@repo`.
+
+- `name` -> `INSTALL name;`
+- `name@repo` -> `INSTALL name FROM repo;`
+
+## Step 1 - Locate DuckDB
+
+```bash
+DUCKDB=$(command -v duckdb)
+```
+
+If DuckDB is not found, tell the user:
+
+> **DuckDB is not installed.** Install it first with one of:
+> - macOS: `brew install duckdb`
+> - Linux: `curl -fsSL https://install.duckdb.org | sh`
+> - Windows: `winget install DuckDB.cli`
+>
+> Then retry this install workflow.
+
+Stop if DuckDB is not found.
+
+## Step 2 - Check For `--update`
+
+If `--update` is present, remove it from the argument list and set mode to **update**. Otherwise set mode to **install**.
+
+## Step 3 - Build And Run Statements
+
+**Install mode**
+
+Parse each remaining argument:
+
+- If it contains `@`, split on `@` -> `INSTALL <name> FROM <repo>;`
+- Otherwise -> `INSTALL <name>;`
+
+Run all statements in a single DuckDB call:
+
+```bash
+"$DUCKDB" :memory: -c "INSTALL <ext1>; INSTALL <ext2> FROM <repo2>; ..."
+```
+
+**Update mode**
+
+First, check whether the DuckDB CLI itself is up to date:
+
+```bash
+CURRENT=$(duckdb --version | grep -oE '[0-9]+\.[0-9]+\.[0-9]+')
+LATEST=$(curl -fsSL https://duckdb.org/data/latest_stable_version.txt)
+```
+
+- If `CURRENT == LATEST`, report that the DuckDB CLI is current.
+- If `CURRENT != LATEST`, ask the user whether to upgrade now.
+
+If the user agrees, detect the platform and run the appropriate upgrade command:
+
+- macOS with Homebrew: `brew upgrade duckdb`
+- Linux: `curl -fsSL https://install.duckdb.org | sh`
+- Windows: `winget upgrade DuckDB.cli`
+
+Then update extensions:
+
+- No extension names -> update all: `UPDATE EXTENSIONS;`
+- With extension names -> update specific extensions in one call, ignoring any `@repo` suffixes:
+
+```bash
+"$DUCKDB" :memory: -c "UPDATE EXTENSIONS;"
+```
+
+or
+
+```bash
+"$DUCKDB" :memory: -c "UPDATE EXTENSIONS (<ext1>, <ext2>, ...);"
+```
+
+Report success or failure after the call completes.
+
+## Validation
+
+For manual smoke tests of representative install commands, use [scripts/eval.sh](scripts/eval.sh).

--- a/skills/duckdb/install-duckdb/scripts/eval.sh
+++ b/skills/duckdb/install-duckdb/scripts/eval.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Smoke tests for the install-duckdb workflow.
+# Runs representative DuckDB INSTALL statements directly and verifies that the
+# listed extensions are loadable afterwards.
+#
+# Prerequisites: duckdb must be in PATH. Network access is required when the
+# requested extension is not already cached locally.
+#
+# Usage:
+#   bash skills/duckdb/install-duckdb/scripts/eval.sh
+#   RUN_COMMUNITY_CASES=1 bash skills/duckdb/install-duckdb/scripts/eval.sh
+#   RUN_UPDATE_CASES=1 bash skills/duckdb/install-duckdb/scripts/eval.sh
+
+set -u
+
+DUCKDB_BIN="${DUCKDB_BIN:-duckdb}"
+PASS=0
+FAIL=0
+TIMINGS=()
+
+if ! command -v "$DUCKDB_BIN" >/dev/null 2>&1; then
+    echo "ERROR: 'duckdb' CLI not found."
+    exit 1
+fi
+
+eval_case() {
+    local desc="$1"; shift
+    local sql="$1"; shift
+    local exts=("$@")
+
+    printf "  %-56s " "$desc"
+    local t0 t1 elapsed result
+    t0=$(date +%s)
+    result=$("$DUCKDB_BIN" :memory: -c "$sql" 2>&1)
+    t1=$(date +%s)
+    elapsed=$((t1 - t0))
+    TIMINGS+=("$elapsed")
+
+    local ext
+    for ext in "${exts[@]}"; do
+        if ! "$DUCKDB_BIN" :memory: -c "LOAD ${ext};" >/dev/null 2>&1; then
+            echo "FAIL  (${elapsed}s) - LOAD ${ext} failed after install"
+            echo "        command output: ${result:0:300}"
+            ((FAIL++))
+            return
+        fi
+    done
+
+    echo "PASS  (${elapsed}s)"
+    ((PASS++))
+}
+
+echo "=== install-duckdb skill eval ==="
+echo "DuckDB bin: $DUCKDB_BIN"
+echo ""
+
+echo "--- Core extensions ---"
+eval_case "Install httpfs"           "INSTALL httpfs;"                    httpfs
+eval_case "Install json"             "INSTALL json;"                      json
+
+echo ""
+echo "--- Multiple extensions ---"
+eval_case "Install spatial + httpfs" "INSTALL spatial; INSTALL httpfs;"   spatial httpfs
+
+if [ "${RUN_COMMUNITY_CASES:-0}" = "1" ]; then
+    echo ""
+    echo "--- Community extensions ---"
+    eval_case "Install magic@community" "INSTALL magic FROM community;" magic
+fi
+
+if [ "${RUN_UPDATE_CASES:-0}" = "1" ]; then
+    echo ""
+    echo "--- Update mode ---"
+    eval_case "Update all extensions"      "UPDATE EXTENSIONS;"
+    eval_case "Update specific extension"  "UPDATE EXTENSIONS (httpfs);" httpfs
+fi
+
+echo ""
+total=0
+for t in "${TIMINGS[@]}"; do
+    total=$((total + t))
+done
+count=${#TIMINGS[@]}
+avg=$(( count > 0 ? total / count : 0 ))
+
+echo "=================================="
+echo "Results : $PASS passed, $FAIL failed"
+echo "Timing  : total ${total}s, avg ${avg}s per case"
+[ "$FAIL" -eq 0 ]

--- a/skills/duckdb/query/SKILL.md
+++ b/skills/duckdb/query/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: query
+description: Run SQL against an attached DuckDB database or ad-hoc against files, including natural-language requests that need SQL generation. Use when the user asks a data question, provides DuckDB SQL, or wants to query files with DuckDB.
+---
+
+# Query
+
+Treat the user's request as either SQL or a natural-language query.
+
+Follow these steps in order.
+
+## Step 1 - Resolve State And Determine The Mode
+
+Look for an existing state file in either location:
+
+```bash
+STATE_DIR=""
+test -f .duckdb-skills/state.sql && STATE_DIR=".duckdb-skills"
+PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")"
+PROJECT_ID="$(echo "$PROJECT_ROOT" | tr '/' '-')"
+test -f "$HOME/.duckdb-skills/$PROJECT_ID/state.sql" && STATE_DIR="$HOME/.duckdb-skills/$PROJECT_ID"
+```
+
+If a state file exists, verify the databases it references are still accessible:
+
+```bash
+duckdb -init "$STATE_DIR/state.sql" -c "SHOW DATABASES;"
+```
+
+Now determine the mode:
+
+- **Ad-hoc mode** if the `--file` flag is present, the SQL references file paths or literals such as `FROM 'data.csv'`, or `STATE_DIR` is empty.
+- **Session mode** if `STATE_DIR` is set and the input references table names, is natural language, or is SQL without file references.
+
+If no state file exists and no file is referenced, fall back to ad-hoc mode against `:memory:`. The user must reference files directly in the SQL.
+
+If the state file exists but any `ATTACH` in it fails, warn the user and fall back to ad-hoc mode.
+
+## Step 2 - Check DuckDB Is Installed
+
+```bash
+command -v duckdb
+```
+
+If not found, open [../install-duckdb/SKILL.md](../install-duckdb/SKILL.md), follow it to install DuckDB, then continue.
+
+## Step 3 - Generate SQL If Needed
+
+If the input is natural language rather than valid SQL, generate SQL using the Friendly SQL reference below.
+
+In **session mode**, first retrieve the schema to inform query generation:
+
+```bash
+duckdb -init "$STATE_DIR/state.sql" -csv -c "
+SELECT table_name FROM duckdb_tables() ORDER BY table_name;
+"
+```
+
+Then, for the relevant tables:
+
+```bash
+duckdb -init "$STATE_DIR/state.sql" -csv -c "DESCRIBE <table_name>;"
+```
+
+Use the schema context and the Friendly SQL reference to generate the most appropriate query.
+
+## Step 4 - Estimate Result Size
+
+Before executing, estimate whether the query could produce a very large result that would consume excessive tokens when returned in the conversation.
+
+**Session mode**: check row counts for the tables involved:
+
+```bash
+duckdb -init "$STATE_DIR/state.sql" -csv -c "
+SELECT table_name, estimated_size, column_count
+FROM duckdb_tables()
+WHERE table_name IN ('<table1>', '<table2>');
+"
+```
+
+**Ad-hoc mode**: probe the source:
+
+```bash
+duckdb :memory: -csv -c "
+SET allowed_paths=['FILE_PATH'];
+SET enable_external_access=false;
+SET allow_persistent_secrets=false;
+SET lock_configuration=true;
+SELECT count() AS row_count FROM 'FILE_PATH';
+"
+```
+
+Evaluate the result:
+
+- If the query already has a `LIMIT`, `count()`, or another aggregation that bounds the output, proceed.
+- If the source has **more than 1M rows** and the query has no `LIMIT` or aggregation, tell the user that the result set will be large and suggest adding `LIMIT 1000` or an aggregation. Ask for confirmation before running it as-is.
+- If the data size is **more than 10 GB**, also warn that the query may take a while. Proceed only if the user confirms.
+
+Skip this step for intrinsically bounded queries such as `DESCRIBE`, `SUMMARIZE`, aggregations, or `count()`.
+
+## Step 5 - Execute The Query
+
+**Ad-hoc mode** with only the referenced files accessible:
+
+```bash
+duckdb :memory: -csv <<'SQL'
+SET allowed_paths=['FILE_PATH'];
+SET enable_external_access=false;
+SET allow_persistent_secrets=false;
+SET lock_configuration=true;
+<QUERY>;
+SQL
+```
+
+Replace `FILE_PATH` with the actual file path extracted from the query or `--file` argument. If multiple files are referenced, include all of them in the `allowed_paths` list.
+
+**Session mode** against the user-trusted database:
+
+```bash
+duckdb -init "$STATE_DIR/state.sql" -csv -c "<QUERY>"
+```
+
+For multi-line queries, use a heredoc with `-init`:
+
+```bash
+duckdb -init "$STATE_DIR/state.sql" -csv <<'SQL'
+<QUERY>;
+SQL
+```
+
+Always use heredocs for multi-line queries to avoid shell-quoting problems.
+
+## Step 6 - Handle Errors
+
+- **Syntax error**: show the error, suggest a corrected query, and retry.
+- **Missing extension**: open [../install-duckdb/SKILL.md](../install-duckdb/SKILL.md), install the missing extension, then retry.
+- **Table not found** in session mode: list available tables from `duckdb_tables()` and suggest corrections.
+- **File not found** in ad-hoc mode: use `find "$PWD" -name "<filename>" 2>/dev/null` to locate the file and suggest the corrected path.
+- **Persistent or unclear DuckDB error**: open [../duckdb-docs/SKILL.md](../duckdb-docs/SKILL.md), search the docs for the error or feature, then apply the fix and retry.
+
+## Step 7 - Present Results
+
+Show the query output to the user. If the result has more than 100 rows, note the truncation and suggest adding `LIMIT`.
+
+For natural-language questions, also provide a brief interpretation of the results.
+
+## DuckDB Friendly SQL Reference
+
+When generating SQL, prefer these idiomatic DuckDB constructs:
+
+### Compact Clauses
+
+- **FROM-first**: `FROM table WHERE x > 10`
+- **GROUP BY ALL**: auto-groups by all non-aggregate columns
+- **ORDER BY ALL**: orders by all columns for deterministic results
+- **SELECT * EXCLUDE (col1, col2)**: drop columns from a wildcard
+- **SELECT * REPLACE (expr AS col)**: transform a column in place
+- **UNION ALL BY NAME**: combine tables with different column orders
+- **Percentage LIMIT**: `LIMIT 10%`
+- **Prefix aliases**: `SELECT x: 42`
+- Trailing commas are allowed in `SELECT` lists
+
+### Query Features
+
+- `count()` instead of `count(*)`
+- Reusable aliases in `WHERE`, `GROUP BY`, and `HAVING`
+- Lateral column aliases such as `SELECT i+1 AS j, j+2 AS k`
+- `COLUMNS(*)` for expressions across columns, including regex, `EXCLUDE`, `REPLACE`, and lambdas
+- `FILTER` clauses for conditional aggregation
+- `GROUPING SETS`, `CUBE`, and `ROLLUP`
+- Top-N-per-group helpers such as `max(col, 3)`, `arg_max(arg, val, n)`, and `min_by(arg, val, n)`
+- `DESCRIBE table_name`
+- `SUMMARIZE table_name`
+- `PIVOT` and `UNPIVOT`
+- `SET VARIABLE x = expr` and `getvariable('x')`
+
+### Data Import
+
+- Direct file queries such as `FROM 'file.csv'` and `FROM 'data.parquet'`
+- Globbing such as `FROM 'data/part-*.parquet'`
+- Automatic CSV header and schema detection
+
+### Expressions And Types
+
+- Dot chaining such as `'hello'.upper()` or `col.trim().lower()`
+- List comprehensions such as `[x*2 FOR x IN list_col]`
+- List and string slicing such as `col[1:3]` and `col[-1]`
+- `STRUCT.*` notation
+- Square-bracket list literals such as `[1, 2, 3]`
+- `format()` for string formatting
+
+### Joins
+
+- `ASOF` joins
+- Positional joins
+- Lateral joins
+
+### Data Modification
+
+- `CREATE OR REPLACE TABLE`
+- `CREATE TABLE ... AS SELECT`
+- `INSERT INTO ... BY NAME`
+- `INSERT OR IGNORE INTO` and `INSERT OR REPLACE INTO`

--- a/skills/duckdb/read-file/SKILL.md
+++ b/skills/duckdb/read-file/SKILL.md
@@ -24,6 +24,8 @@ For **remote files**, prepend the necessary `LOAD` and `CREATE SECRET` statement
 
 For **local files**, no prefix is needed.
 
+The SQLite branch of the `read_any` macro intentionally reads only the first table returned by `sqlite_master(file_name)`. If the user needs a specific SQLite table, list the tables first and then switch to an explicit call such as `sqlite_scan(file_name, '<table_name>')`.
+
 ```bash
 duckdb -csv -c "
 CREATE OR REPLACE MACRO read_any(file_name) AS TABLE

--- a/skills/duckdb/read-file/SKILL.md
+++ b/skills/duckdb/read-file/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: read-file
+description: Read data files or remote URLs with DuckDB, including CSV, JSON, Parquet, Avro, Excel, spatial formats, and SQLite files. Use when the user asks what is in a dataset, wants a schema or sample, or needs quick profiling of a data file. Not for source code.
+---
+
+# Read File
+
+Treat the user's file path or URL as the target dataset. If the user asks a follow-up question about the dataset, answer it after inspection.
+
+## Step 1 - Read It
+
+`RESOLVED_PATH` is the path or URL the user provided. If the user gave a bare filename with no `/`, resolve it to a full path with `find`.
+
+Run a single DuckDB command that defines the `read_any` macro inline and reads the file.
+
+For **remote files**, prepend the necessary `LOAD` and `CREATE SECRET` statements before the macro:
+
+| Protocol | Prepend |
+| --- | --- |
+| `https://`, `http://` | `LOAD httpfs;` |
+| `s3://` | `LOAD httpfs; CREATE SECRET (TYPE S3, PROVIDER credential_chain);` |
+| `gs://`, `gcs://` | `LOAD httpfs; CREATE SECRET (TYPE GCS, PROVIDER credential_chain);` |
+| `az://`, `azure://`, `abfss://` | `LOAD httpfs; LOAD azure; CREATE SECRET (TYPE AZURE, PROVIDER credential_chain);` |
+
+For **local files**, no prefix is needed.
+
+```bash
+duckdb -csv -c "
+CREATE OR REPLACE MACRO read_any(file_name) AS TABLE
+  WITH json_case AS (FROM read_json_auto(file_name))
+     , csv_case AS (FROM read_csv(file_name))
+     , parquet_case AS (FROM read_parquet(file_name))
+     , avro_case AS (FROM read_avro(file_name))
+     , blob_case AS (FROM read_blob(file_name))
+     , spatial_case AS (FROM st_read(file_name))
+     , excel_case AS (FROM read_xlsx(file_name))
+     , sqlite_case AS (FROM sqlite_scan(file_name, (SELECT name FROM sqlite_master(file_name) LIMIT 1)))
+     , ipynb_case AS (
+         WITH nb AS (FROM read_json_auto(file_name))
+         SELECT cell_idx, cell.cell_type,
+                array_to_string(cell.source, '') AS source,
+                cell.execution_count
+         FROM nb, UNNEST(cells) WITH ORDINALITY AS t(cell, cell_idx)
+         ORDER BY cell_idx
+     )
+  FROM query_table(
+    CASE
+      WHEN file_name ILIKE '%.json' OR file_name ILIKE '%.jsonl' OR file_name ILIKE '%.ndjson' OR file_name ILIKE '%.geojson' OR file_name ILIKE '%.geojsonl' OR file_name ILIKE '%.har' THEN 'json_case'
+      WHEN file_name ILIKE '%.csv' OR file_name ILIKE '%.tsv' OR file_name ILIKE '%.tab' OR file_name ILIKE '%.txt' THEN 'csv_case'
+      WHEN file_name ILIKE '%.parquet' OR file_name ILIKE '%.pq' THEN 'parquet_case'
+      WHEN file_name ILIKE '%.avro' THEN 'avro_case'
+      WHEN file_name ILIKE '%.xlsx' OR file_name ILIKE '%.xls' THEN 'excel_case'
+      WHEN file_name ILIKE '%.shp' OR file_name ILIKE '%.gpkg' OR file_name ILIKE '%.fgb' OR file_name ILIKE '%.kml' THEN 'spatial_case'
+      WHEN file_name ILIKE '%.ipynb' THEN 'ipynb_case'
+      WHEN file_name ILIKE '%.db' OR file_name ILIKE '%.sqlite' OR file_name ILIKE '%.sqlite3' THEN 'sqlite_case'
+      ELSE 'blob_case'
+    END
+  );
+
+DESCRIBE FROM read_any('RESOLVED_PATH');
+SELECT count(*) AS row_count FROM read_any('RESOLVED_PATH');
+FROM read_any('RESOLVED_PATH') LIMIT 20;
+"
+```
+
+If this fails:
+
+- **`duckdb: command not found`** -> open [../install-duckdb/SKILL.md](../install-duckdb/SKILL.md), install DuckDB, then retry
+- **Missing extension** for spatial files, xlsx, or sqlite -> retry with the matching `INSTALL` and `LOAD` statements prepended
+- **Wrong reader or parse error** -> use the correct `read_*` function directly instead of `read_any`
+
+## Step 2 - Answer
+
+Using the schema, row count, and sample rows, answer the user's requested question, or provide a default summary of column types, row count, and notable patterns.

--- a/skills/duckdb/read-memories/SKILL.md
+++ b/skills/duckdb/read-memories/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: read-memories
+description: Search prior agent session logs stored as JSONL to recover decisions, patterns, or unresolved work. Use when the user references past conversations, asks what was done before, or wants context recovered from local transcript files.
+---
+
+# Read Memories
+
+Search past session logs silently. Do not narrate the lookup process; absorb the results and continue with enriched context.
+
+Treat the first argument as the keyword or phrase to search. Treat `--here` as a request to scope the search to the current project when the log layout supports project-specific directories.
+
+## Step 1 - Resolve The Search Path
+
+First resolve a compatible log root:
+
+- If the user supplied a path to transcript files, use it.
+- Otherwise, if `$HOME/.claude/projects` exists, use the Claude Code JSONL layout from the upstream DuckDB skill.
+- Otherwise, ask the user for the transcript directory or report that no compatible local session log store was found.
+
+Once you have a log root, query it with DuckDB:
+
+```bash
+duckdb :memory: -c "
+SELECT
+  regexp_extract(filename, 'projects/([^/]+)/', 1) AS project,
+  strftime(timestamp::TIMESTAMPTZ, '%Y-%m-%d %H:%M') AS ts,
+  message.role AS role,
+  left(message.content::VARCHAR, 500) AS content
+FROM read_ndjson('<SEARCH_PATH>', auto_detect=true, ignore_errors=true, filename=true)
+WHERE message::VARCHAR ILIKE '%<KEYWORD>%'
+  AND message.role IS NOT NULL
+ORDER BY timestamp
+LIMIT 40;
+"
+```
+
+Common search paths:
+
+- All Claude Code projects: `$HOME/.claude/projects/*/*.jsonl`
+- Current Claude Code project with `--here`: `$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/_]|-|g')/*.jsonl`
+
+Replace `<SEARCH_PATH>` and `<KEYWORD>` before running.
+
+## Step 2 - Internalize
+
+From the results, extract decisions, patterns, unresolved TODOs, and user corrections. Use this to inform the current response. Do not repeat raw transcript lines unless the user explicitly asks for them.

--- a/skills/duckdb/read-memories/SKILL.md
+++ b/skills/duckdb/read-memories/SKILL.md
@@ -19,6 +19,13 @@ First resolve a compatible log root:
 
 Once you have a log root, query it with DuckDB:
 
+Before constructing the SQL, escape any single quotes in the search term by doubling them:
+
+```bash
+KEYWORD="<KEYWORD>"
+SQL_KEYWORD=${KEYWORD//\'/\'\'}
+```
+
 ```bash
 duckdb :memory: -c "
 SELECT
@@ -27,7 +34,7 @@ SELECT
   message.role AS role,
   left(message.content::VARCHAR, 500) AS content
 FROM read_ndjson('<SEARCH_PATH>', auto_detect=true, ignore_errors=true, filename=true)
-WHERE message::VARCHAR ILIKE '%<KEYWORD>%'
+WHERE message::VARCHAR ILIKE '%<SQL_KEYWORD>%'
   AND message.role IS NOT NULL
 ORDER BY timestamp
 LIMIT 40;
@@ -39,7 +46,7 @@ Common search paths:
 - All Claude Code projects: `$HOME/.claude/projects/*/*.jsonl`
 - Current Claude Code project with `--here`: `$HOME/.claude/projects/$(echo "$PWD" | sed 's|[/_]|-|g')/*.jsonl`
 
-Replace `<SEARCH_PATH>` and `<KEYWORD>` before running.
+Replace `<SEARCH_PATH>` and `<SQL_KEYWORD>` before running. Use the escaped `SQL_KEYWORD`, not the raw keyword, anywhere the term is interpolated into SQL.
 
 ## Step 2 - Internalize
 

--- a/skills/duckdb/s3-explore/SKILL.md
+++ b/skills/duckdb/s3-explore/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: s3-explore
+description: Explore and query data on S3, Cloudflare R2, GCS, MinIO, or compatible object storage with DuckDB. Use when the user mentions `s3://`, `r2://`, `gs://`, or `gcs://` URLs, asks what is in a bucket, or wants schema, size, sample, or query results from remote data without downloading it first.
+---
+
+# S3 Explore
+
+Treat the user's object-storage URL as the target location. If the user asked a follow-up question, answer it after inspection.
+
+## Step 1 - Detect The Provider And Set Up Credentials
+
+Based on the URL or user context, prepend the appropriate secret configuration:
+
+| Provider | URL patterns | Secret setup |
+| --- | --- | --- |
+| **AWS S3** | `s3://` | `CREATE SECRET (TYPE S3, PROVIDER credential_chain);` |
+| **Cloudflare R2** | `r2://`, or `s3://` with an R2 endpoint | `CREATE SECRET (TYPE R2, PROVIDER credential_chain);` |
+| **GCS** | `gs://`, `gcs://` | `CREATE SECRET (TYPE GCS, PROVIDER credential_chain);` |
+| **MinIO or custom** | `s3://` with a custom endpoint | `CREATE SECRET (TYPE S3, KEY_ID '...', SECRET '...', ENDPOINT '...', USE_SSL true);` |
+
+For R2, if the user provides an account ID, the endpoint is `<account_id>.r2.cloudflarestorage.com`. R2 URLs such as `r2://bucket/path` should be rewritten to `s3://bucket/path` with the R2 secret.
+
+For public buckets, skip the secret setup.
+
+Always prepend:
+
+```sql
+LOAD httpfs;
+```
+
+## Step 2 - Determine What The URL Points To
+
+If the URL looks like a directory or bucket, meaning no file extension or a trailing slash, list its contents with sizes:
+
+```bash
+duckdb -c "
+LOAD httpfs;
+<SECRET_SETUP>
+SELECT filename, (size / 1024 / 1024)::DECIMAL(10,1) AS size_mb, last_modified
+FROM read_blob('<URL>/*')
+ORDER BY filename
+LIMIT 50;
+"
+```
+
+Only select `filename`, `size`, and `last_modified`. Never select `content`, which would download file bodies.
+
+If the URL points to a specific file or glob pattern, preview it:
+
+```bash
+duckdb -c "
+LOAD httpfs;
+<SECRET_SETUP>
+DESCRIBE FROM '<URL>';
+SELECT count(*) AS row_count FROM '<URL>';
+FROM '<URL>' LIMIT 20;
+"
+```
+
+For Parquet files, get row counts and sizes from metadata without downloading row data:
+
+```bash
+duckdb -c "
+LOAD httpfs;
+<SECRET_SETUP>
+SELECT file_name,
+       sum(row_group_num_rows) AS total_rows,
+       (sum(row_group_compressed_bytes) / 1024 / 1024)::DECIMAL(10,1) AS compressed_mb
+FROM parquet_metadata('<URL>')
+GROUP BY file_name;
+"
+```
+
+## Step 3 - Answer The Question
+
+Using the listing, schema, or sample data, answer the user's question.
+
+If the user asks an analytical question such as "how many rows match X", write and run the appropriate SQL query. DuckDB pushes predicates down into Parquet on object storage, so filtered queries can still be efficient.
+
+## Error Handling
+
+- **`duckdb: command not found`** -> open [../install-duckdb/SKILL.md](../install-duckdb/SKILL.md), install DuckDB, then retry
+- **Access denied or 403** -> suggest checking credentials such as `aws configure`, environment variables, or explicit keys
+- **Bucket not found or 404** -> check the URL and region
+- **Timeout on a large listing** -> suggest narrowing the glob pattern or adding a prefix

--- a/skills/duckdb/spatial/SKILL.md
+++ b/skills/duckdb/spatial/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: spatial
+description: Answer spatial-data questions with DuckDB, including coordinate work, distance calculations, spatial joins, containment checks, density analysis, and geographic format conversion. Use when the user mentions maps, locations, coordinates, nearby places, GeoJSON, Shapefile, GeoPackage, GPX, GeoParquet, or Overture Maps data.
+---
+
+# Spatial
+
+Treat the user's request as either a spatial question or a spatial dataset to inspect.
+
+## Step 1 - Understand What The User Needs
+
+Classify the question:
+
+| Pattern | Data source | Key functions |
+| --- | --- | --- |
+| "Find X near Y" with no user file | Overture Maps on S3 | `ST_Distance_Spheroid`, bbox filtering |
+| "How far between A and B" | Geocoded points or user data | `ST_Distance_Spheroid` |
+| "Which points fall inside polygons" | User files | `ST_Contains` |
+| "Analyze this GeoJSON, Shapefile, or GPX" | User file | `ST_Read`, measurement functions |
+| "Show density or hotspots" | User data or Overture | H3 hex binning |
+| "Convert to GeoJSON or GeoPackage" | User file | `COPY TO (FORMAT GDAL)` |
+| "Count buildings or roads in an area" | Overture Maps | bbox filtering plus aggregation |
+
+If the question involves real-world places, POIs, buildings, roads, or boundaries and the user has not provided a file, use **Overture Maps**. Read [references/overture.rst](references/overture.rst) for S3 paths and schema.
+
+For spatial function syntax, read [references/functions.rst](references/functions.rst).
+
+## Step 2 - Write And Run The Query
+
+Always start with:
+
+```sql
+LOAD spatial;
+SET geometry_always_xy = true;
+```
+
+Add extensions as needed:
+
+- Overture or other remote data: `LOAD httpfs; CREATE SECRET (TYPE S3, PROVIDER config, REGION 'us-west-2');`
+- H3 hex binning: `INSTALL h3 FROM community; LOAD h3;`
+
+### Key Principles
+
+**bbox filtering first**: When querying Overture, always filter on `bbox.xmin`, `bbox.xmax`, `bbox.ymin`, and `bbox.ymax` before any spatial function. This uses Parquet predicate pushdown and avoids downloading the full dataset.
+
+**Always set `geometry_always_xy = true`**: This ensures all spatial functions interpret coordinates as longitude, latitude. Without it, spheroid functions assume latitude first and return incorrect results.
+
+**Use spheroid functions for real-world distances**: `ST_Distance_Spheroid` returns meters on WGS84. Plain `ST_Distance` uses planar coordinates and is usually wrong for longitude and latitude.
+
+**`POINT_2D` requirement**: Spheroid functions such as `ST_Distance_Spheroid`, `ST_Area_Spheroid`, and `ST_DWithin_Spheroid` require `POINT_2D` inputs rather than generic `GEOMETRY`. Extract coordinates first:
+
+```sql
+ST_Point(ST_X(geometry), ST_Y(geometry))::POINT_2D
+```
+
+**CSV with lat/lng needs conversion**: Use `ST_Point(longitude, latitude)`, with longitude first.
+
+Run the query in a single shell call:
+
+```bash
+duckdb -c "
+LOAD spatial;
+<ADDITIONAL_SETUP>
+<YOUR_QUERY>
+"
+```
+
+## Step 3 - Present Results
+
+- For tabular results, show the data directly.
+- For spatial results, consider exporting to GeoJSON for visualization with `COPY TO 'result.geojson' WITH (FORMAT GDAL, DRIVER 'GeoJSON')`.
+- For distance or area results, use human-readable units such as `km` or `m`.
+- For density or hotspot results, describe the pattern and offer to export the result for visualization.
+
+If the query fails:
+
+- **`duckdb: command not found`** -> open [../install-duckdb/SKILL.md](../install-duckdb/SKILL.md), install DuckDB, then retry
+- **Missing extension** -> run `INSTALL spatial; LOAD spatial;` or `INSTALL h3 FROM community; LOAD h3;`
+- **S3 access denied** -> suggest checking AWS credentials
+- **No results with Overture** -> widen the bounding box, check category spelling, or try a broader search

--- a/skills/duckdb/spatial/SKILL.md
+++ b/skills/duckdb/spatial/SKILL.md
@@ -55,14 +55,14 @@ ST_Point(ST_X(geometry), ST_Y(geometry))::POINT_2D
 
 **CSV with lat/lng needs conversion**: Use `ST_Point(longitude, latitude)`, with longitude first.
 
-Run the query in a single shell call:
+Run the query in a single shell call. Prefer a heredoc for multi-line SQL so shell quoting does not break complex spatial queries:
 
 ```bash
-duckdb -c "
+duckdb <<'SQL'
 LOAD spatial;
 <ADDITIONAL_SETUP>
 <YOUR_QUERY>
-"
+SQL
 ```
 
 ## Step 3 - Present Results

--- a/skills/duckdb/spatial/references/functions.rst
+++ b/skills/duckdb/spatial/references/functions.rst
@@ -1,0 +1,273 @@
+DuckDB Spatial Functions Reference
+==================================
+
+.. note::
+
+   This reference is vendored from DuckDB's upstream skill set and converted to
+   reStructuredText for this repository.
+
+Setup
+-----
+
+.. code:: sql
+
+   INSTALL spatial; LOAD spatial;
+   SET geometry_always_xy = true;  -- ensures lng/lat order for all spatial functions
+   -- For H3 hex binning:
+   INSTALL h3 FROM community; LOAD h3;
+
+Reading spatial files
+---------------------
+
++--------------------------+----------------------------------------------------------+
+| Format                   | Read method                                              |
++==========================+==========================================================+
+| GeoJSON                  | ``ST_Read('file.geojson')``                              |
++--------------------------+----------------------------------------------------------+
+| Shapefile                | ``ST_Read('file.shp')``                                  |
++--------------------------+----------------------------------------------------------+
+| GeoPackage               | ``ST_Read('file.gpkg')``                                 |
++--------------------------+----------------------------------------------------------+
+| FlatGeobuf               | ``ST_Read('file.fgb')``                                  |
++--------------------------+----------------------------------------------------------+
+| KML                      | ``ST_Read('file.kml')``                                  |
++--------------------------+----------------------------------------------------------+
+| GPX                      | ``ST_Read('file.gpx')``                                  |
++--------------------------+----------------------------------------------------------+
+| GeoParquet               | ``FROM 'file.geoparquet'`` (native, no ST_Read needed)   |
++--------------------------+----------------------------------------------------------+
+| OSM PBF                  | ``ST_ReadOSM('region.osm.pbf')`` (multithreaded, tags as |
+|                          | MAP column)                                              |
++--------------------------+----------------------------------------------------------+
+| CSV with lat/lng         | ``SELECT *, ST_Point(lng, lat) AS geom FROM 'file.csv'`` |
++--------------------------+----------------------------------------------------------+
+
+``ST_Read`` uses GDAL internally and supports 50+ formats.
+
+Writing spatial files
+---------------------
+
+.. code:: sql
+
+   COPY (SELECT * FROM ...) TO 'out.geojson' WITH (FORMAT GDAL, DRIVER 'GeoJSON');
+   COPY (SELECT * FROM ...) TO 'out.gpkg' WITH (FORMAT GDAL, DRIVER 'GPKG');
+   COPY (SELECT * FROM ...) TO 'out.shp' WITH (FORMAT GDAL, DRIVER 'ESRI Shapefile');
+   COPY (SELECT * FROM ...) TO 'out.fgb' WITH (FORMAT GDAL, DRIVER 'FlatGeobuf');
+
+Set ``geometry_always_xy = true`` before writing to avoid axis order
+issues with KML or WGS84.
+
+Key functions
+-------------
+
+Construction
+~~~~~~~~~~~~
+
++---------------------------------------------+---------------------------------------+
+| Function                                    | Description                           |
++=============================================+=======================================+
+| ``ST_Point(x, y)``                          | Create point from lon, lat            |
++---------------------------------------------+---------------------------------------+
+| ``ST_MakeEnvelope(xmin, ymin, xmax, ymax)`` | Create bounding box rectangle         |
++---------------------------------------------+---------------------------------------+
+| ``ST_GeomFromText('POLYGON(...)')``         | Parse WKT                             |
++---------------------------------------------+---------------------------------------+
+| ``ST_GeomFromGeoJSON('{"type":...}')``      | Parse GeoJSON                         |
++---------------------------------------------+---------------------------------------+
+| ``ST_MakeLine(geom_array)``                 | Create line from points               |
++---------------------------------------------+---------------------------------------+
+
+Distance & proximity
+~~~~~~~~~~~~~~~~~~~~
+
++-------------------------------------+---------------------------------------+
+| Function                            | Description                           |
++=====================================+=======================================+
+| ``ST_Distance(a, b)``               | Planar distance (units depend on      |
+|                                     | CRS). Accepts any ``GEOMETRY``.       |
++-------------------------------------+---------------------------------------+
+| ``ST_Distance_Spheroid(a, b)``      | Geodesic distance in **meters**       |
+|                                     | (WGS84). **Requires ``POINT_2D``      |
+|                                     | inputs** - see note below.            |
++-------------------------------------+---------------------------------------+
+| ``ST_DWithin(a, b, dist)``          | Is planar distance <= dist?            |
++-------------------------------------+---------------------------------------+
+| ``ST_DWithin_Spheroid(a, b, dist)`` | Is geodesic distance <= dist meters?   |
+|                                     | **Requires ``POINT_2D`` inputs.**     |
++-------------------------------------+---------------------------------------+
+
+..
+
+   **``POINT_2D`` requirement:** Spheroid functions
+   (``ST_Distance_Spheroid``, ``ST_Area_Spheroid``,
+   ``ST_Length_Spheroid``, ``ST_DWithin_Spheroid``) only accept
+   ``POINT_2D``, not generic ``GEOMETRY``. Overture Maps and
+   ``ST_Read()`` return ``GEOMETRY`` types that cannot be cast directly.
+   Extract and rebuild:
+
+   .. code:: sql
+
+      ST_Point(ST_X(geometry), ST_Y(geometry))::POINT_2D
+
+Spatial relationships
+~~~~~~~~~~~~~~~~~~~~~
+
+======================= ====================================
+Function                Returns true when
+======================= ====================================
+``ST_Contains(a, b)``   a fully contains b
+``ST_Within(a, b)``     a is fully within b
+``ST_Intersects(a, b)`` a and b share any space
+``ST_Covers(a, b)``     a covers b (no boundary distinction)
+``ST_Disjoint(a, b)``   a and b share no space
+``ST_Touches(a, b)``    a and b touch at boundary only
+======================= ====================================
+
+Measurement
+~~~~~~~~~~~
+
+============================ ==================================
+Function                     Description
+============================ ==================================
+``ST_Area(geom)``            Planar area
+``ST_Area_Spheroid(geom)``   Geodesic area in **square meters**
+``ST_Length(geom)``          Planar length of linestring
+``ST_Length_Spheroid(geom)`` Geodesic length in **meters**
+``ST_Perimeter(geom)``       Perimeter of polygon
+``ST_NPoints(geom)``         Number of vertices
+============================ ==================================
+
+Transformation
+~~~~~~~~~~~~~~
+
++------------------------------------------------+----------------------------------+
+| Function                                       | Description                      |
++================================================+==================================+
+| ``ST_Transform(geom, 'EPSG:from', 'EPSG:to')`` | Reproject                        |
++------------------------------------------------+----------------------------------+
+| ``ST_Centroid(geom)``                          | Center point                     |
++------------------------------------------------+----------------------------------+
+| ``ST_Buffer(geom, dist)``                      | Buffer/expand geometry           |
++------------------------------------------------+----------------------------------+
+| ``ST_Simplify(geom, tolerance)``               | Simplify (Douglas-Peucker)       |
++------------------------------------------------+----------------------------------+
+| ``ST_ConvexHull(geom)``                        | Convex hull                      |
++------------------------------------------------+----------------------------------+
+| ``ST_Union(a, b)``                             | Merge two geometries             |
++------------------------------------------------+----------------------------------+
+| ``ST_Intersection(a, b)``                      | Intersection of two geometries   |
++------------------------------------------------+----------------------------------+
+| ``ST_Difference(a, b)``                        | Subtract b from a                |
++------------------------------------------------+----------------------------------+
+| ``ST_FlipCoordinates(geom)``                   | Swap x/y (for axis order issues) |
++------------------------------------------------+----------------------------------+
+
+Aggregation
+~~~~~~~~~~~
+
+======================= ==============================
+Function                Description
+======================= ==============================
+``ST_Extent_Agg(geom)`` Bounding box of all geometries
+``ST_Union_Agg(geom)``  Union of all geometries
+``ST_Collect(array)``   Create GeometryCollection
+======================= ==============================
+
+Accessors
+~~~~~~~~~
+
+================================ ================================
+Function                         Description
+================================ ================================
+``ST_X(point)``                  Get longitude
+``ST_Y(point)``                  Get latitude
+``ST_GeometryType(geom)``        Type name (POINT, POLYGON, etc.)
+``ST_AsText(geom)``              WKT representation
+``ST_AsGeoJSON(geom)``           GeoJSON representation
+``ST_XMin/XMax/YMin/YMax(geom)`` Bounding box coordinates
+================================ ================================
+
+H3 hexagonal binning
+--------------------
+
+H3 converts lat/lng to hexagonal cells at different resolutions. Great
+for density maps and hotspot analysis.
+
+========== ========= ====================
+Resolution Avg edge  Use case
+========== ========= ====================
+0          ~1,107 km Continental
+3          ~59 km    Metropolitan regions
+5          ~8 km     Cities
+7          ~1.2 km   Neighborhoods
+9          ~174 m    City blocks
+11         ~25 m     Individual buildings
+13         ~3.3 m    Parking spots
+========== ========= ====================
+
+Key functions:
+
+.. code:: sql
+
+   -- Point to hex cell
+   h3_latlng_to_cell(lat, lng, resolution) -> UBIGINT
+
+   -- Hex cell to center point
+   h3_cell_to_latlng(cell) -> STRUCT(lat, lng)
+
+   -- Hex cell to polygon boundary (for visualization)
+   h3_cell_to_boundary_wkt(cell) -> VARCHAR (WKT)
+
+   -- Ring of cells around a center
+   h3_grid_disk(cell, k) -> UBIGINT[] (all cells within k rings)
+
+   -- Density example: count points per hex
+   SELECT h3_latlng_to_cell(lat, lng, 7) AS hex,
+          count(*) AS cnt,
+          h3_cell_to_boundary_wkt(hex) AS boundary
+   FROM my_points
+   GROUP BY hex
+   ORDER BY cnt DESC;
+
+Common patterns
+---------------
+
+CSV with lat/lng -> spatial queries
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: sql
+
+   SELECT *, ST_Point(longitude, latitude) AS geom FROM 'data.csv';
+
+Distance matrix between all pairs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: sql
+
+   SELECT a.name, b.name,
+          ST_Distance_Spheroid(a.geom, b.geom) AS dist_m
+   FROM locations a, locations b
+   WHERE a.name < b.name;
+
+Points inside polygons
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: sql
+
+   SELECT p.name, z.zone_name
+   FROM points p, zones z
+   WHERE ST_Contains(z.geom, p.geom);
+
+Nearest neighbor (top-K per row)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: sql
+
+   SELECT a.name, b.name AS nearest,
+          ST_Distance_Spheroid(a.geom, b.geom) AS dist_m
+   FROM locations a
+   CROSS JOIN LATERAL (
+       SELECT name, geom FROM targets b
+       ORDER BY ST_Distance_Spheroid(a.geom, b.geom)
+       LIMIT 3
+   ) b;

--- a/skills/duckdb/spatial/references/overture.rst
+++ b/skills/duckdb/spatial/references/overture.rst
@@ -1,0 +1,226 @@
+Overture Maps Reference
+=======================
+
+.. note::
+
+   The release number in this vendored reference reflects the upstream
+   ``duckdb-skills`` snapshot pinned in ``skills/duckdb/upstream.json``. If
+   freshness matters, inspect the STAC catalog before hard-coding a release
+   path.
+
+Overture Maps is a free, open global dataset - POIs, buildings, roads,
+boundaries - distributed as GeoParquet on S3. No API keys, no downloads,
+no registration.
+
+Access
+------
+
+.. code:: sql
+
+   LOAD httpfs;
+   LOAD spatial;
+   CREATE SECRET (TYPE S3, PROVIDER config, REGION 'us-west-2');
+
+S3 paths
+--------
+
+Use the STAC catalog at ``https://stac.overturemaps.org/catalog.json``
+to find the latest release. As of 2026-03-18, the latest release is
+``2026-03-18.0``.
+
+Base path: ``s3://overturemaps-us-west-2/release/<RELEASE>/``
+
++------------------+---------------+------------------------------------------+
+| Theme            | Type          | Path suffix                              |
++==================+===============+==========================================+
+| Places (POIs)    | place         | ``theme=places/type=place/*``            |
++------------------+---------------+------------------------------------------+
+| Buildings        | building      | ``theme=buildings/type=building/*``      |
++------------------+---------------+------------------------------------------+
+| Transportation   | segment       | ``theme=transportation/type=segment/*``  |
++------------------+---------------+------------------------------------------+
+| Divisions (admin | division      | ``theme=divisions/type=division/*``      |
+| boundaries)      |               |                                          |
++------------------+---------------+------------------------------------------+
+| Division areas   | division_area | ``theme=divisions/type=division_area/*`` |
+| (polygons)       |               |                                          |
++------------------+---------------+------------------------------------------+
+| Addresses        | address       | ``theme=addresses/type=address/*``       |
++------------------+---------------+------------------------------------------+
+| Base (land,      | various       | ``theme=base/type=land/*`` etc.          |
+| water, land_use) |               |                                          |
++------------------+---------------+------------------------------------------+
+
+Efficient querying - bbox filtering
+-----------------------------------
+
+Overture files are partitioned by bounding box. Use ``bbox.*`` columns
+for predicate pushdown - this avoids downloading the entire dataset:
+
+.. code:: sql
+
+   FROM read_parquet('s3://overturemaps-us-west-2/release/2026-03-18.0/theme=places/type=place/*')
+   WHERE bbox.xmin > -74.00 AND bbox.xmax < -73.97
+     AND bbox.ymin > 40.74 AND bbox.ymax < 40.76
+
+Always filter on bbox first, then apply additional filters.
+
+Schema: Places
+--------------
+
++------------------------------+---------------+-----------------------------------+
+| Field                        | Type          | Description                       |
++==============================+===============+===================================+
+| ``id``                       | VARCHAR       | Unique identifier                 |
++------------------------------+---------------+-----------------------------------+
+| ``geometry``                 | GEOMETRY      | Point location                    |
++------------------------------+---------------+-----------------------------------+
+| ``bbox.xmin/xmax/ymin/ymax`` | DOUBLE        | Bounding box (for pushdown)       |
++------------------------------+---------------+-----------------------------------+
+| ``names.primary``            | VARCHAR       | Primary name                      |
++------------------------------+---------------+-----------------------------------+
+| ``categories.primary``       | VARCHAR       | Primary category (e.g.,           |
+|                              |               | ``coffee_shop``, ``restaurant``,  |
+|                              |               | ``hospital``)                     |
++------------------------------+---------------+-----------------------------------+
+| ``categories.alternate``     | VARCHAR[]     | Additional categories             |
++------------------------------+---------------+-----------------------------------+
+| ``confidence``               | DOUBLE        | 0-1 confidence score              |
++------------------------------+---------------+-----------------------------------+
+| ``addresses[1].freeform``    | VARCHAR       | Full address text                 |
++------------------------------+---------------+-----------------------------------+
+| ``addresses[1].locality``    | VARCHAR       | City/town                         |
++------------------------------+---------------+-----------------------------------+
+| ``addresses[1].country``     | VARCHAR       | Country code                      |
++------------------------------+---------------+-----------------------------------+
+| ``websites``                 | VARCHAR[]     | URLs                              |
++------------------------------+---------------+-----------------------------------+
+| ``phones``                   | VARCHAR[]     | Phone numbers                     |
++------------------------------+---------------+-----------------------------------+
+| ``brand.names.primary``      | VARCHAR       | Brand name                        |
++------------------------------+---------------+-----------------------------------+
+
+Schema: Buildings
+-----------------
+
+================= ======== ==========================
+Field             Type     Description
+================= ======== ==========================
+``id``            VARCHAR  Unique identifier
+``geometry``      GEOMETRY Polygon footprint
+``names.primary`` VARCHAR  Building name (often null)
+``class``         VARCHAR  Building class
+``height``        DOUBLE   Height in meters
+``num_floors``    INTEGER  Number of floors
+``roof_shape``    VARCHAR  Roof shape
+================= ======== ==========================
+
+Schema: Divisions
+-----------------
+
++-------------------+---------------+-----------------------------------+
+| Field             | Type          | Description                       |
++===================+===============+===================================+
+| ``id``            | VARCHAR       | Unique identifier                 |
++-------------------+---------------+-----------------------------------+
+| ``geometry``      | GEOMETRY      | Point (representative location)   |
++-------------------+---------------+-----------------------------------+
+| ``names.primary`` | VARCHAR       | Division name                     |
++-------------------+---------------+-----------------------------------+
+| ``subtype``       | VARCHAR       | ``country``, ``region``,          |
+|                   |               | ``county``, ``locality``, etc.    |
++-------------------+---------------+-----------------------------------+
+| ``admin_level``   | INTEGER       | Hierarchy level                   |
++-------------------+---------------+-----------------------------------+
+| ``population``    | INTEGER       | Population                        |
++-------------------+---------------+-----------------------------------+
+| ``country``       | VARCHAR       | ISO 3166-1 alpha-2                |
++-------------------+---------------+-----------------------------------+
+
+Schema: Division Areas (boundaries)
+-----------------------------------
+
+================= ======== =====================
+Field             Type     Description
+================= ======== =====================
+``id``            VARCHAR  Unique identifier
+``geometry``      GEOMETRY MultiPolygon boundary
+``division_id``   VARCHAR  Links to division
+``names.primary`` VARCHAR  Area name
+``subtype``       VARCHAR  Same as divisions
+``country``       VARCHAR  ISO 3166-1 alpha-2
+================= ======== =====================
+
+Schema: Transportation Segments
+-------------------------------
+
++-------------------+---------------+-----------------------------------+
+| Field             | Type          | Description                       |
++===================+===============+===================================+
+| ``id``            | VARCHAR       | Unique identifier                 |
++-------------------+---------------+-----------------------------------+
+| ``geometry``      | GEOMETRY      | LineString centerline             |
++-------------------+---------------+-----------------------------------+
+| ``names.primary`` | VARCHAR       | Road name                         |
++-------------------+---------------+-----------------------------------+
+| ``class``         | VARCHAR       | Road class (motorway, primary,    |
+|                   |               | secondary, tertiary, residential, |
+|                   |               | etc.)                             |
++-------------------+---------------+-----------------------------------+
+| ``subtype``       | VARCHAR       | road, rail, water                 |
++-------------------+---------------+-----------------------------------+
+| ``speed_limits``  | STRUCT[]      | Speed limit rules                 |
++-------------------+---------------+-----------------------------------+
+
+Common queries
+--------------
+
+Find places by category near a point
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: sql
+
+   SELECT names.primary, categories.primary, confidence,
+          ST_Distance_Spheroid(
+            ST_Point(ST_X(geometry), ST_Y(geometry))::POINT_2D,
+            ST_Point(-73.985, 40.748)::POINT_2D
+          ) AS dist_m
+   FROM read_parquet('s3://overturemaps-us-west-2/release/2026-03-18.0/theme=places/type=place/*')
+   WHERE bbox.xmin BETWEEN -74.01 AND -73.96
+     AND bbox.ymin BETWEEN 40.72 AND 40.77
+     AND categories.primary = 'coffee_shop'
+   ORDER BY dist_m
+   LIMIT 10;
+
+Count buildings in a city
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: sql
+
+   SELECT count(*) AS buildings
+   FROM read_parquet('s3://overturemaps-us-west-2/release/2026-03-18.0/theme=buildings/type=building/*')
+   WHERE bbox.xmin BETWEEN -122.75 AND -122.55
+     AND bbox.ymin BETWEEN 45.45 AND 45.60;
+
+Join user data with Overture
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. code:: sql
+
+   -- Find nearest Overture place to each row in user's CSV
+   SELECT u.*, p.names.primary AS nearest_place, p.categories.primary AS category,
+          ST_Distance_Spheroid(
+            ST_Point(u.longitude, u.latitude)::POINT_2D,
+            ST_Point(ST_X(p.geometry), ST_Y(p.geometry))::POINT_2D
+          ) AS dist_m
+   FROM 'user_locations.csv' u
+   CROSS JOIN LATERAL (
+       SELECT * FROM read_parquet('s3://overturemaps-us-west-2/release/2026-03-18.0/theme=places/type=place/*')
+       WHERE bbox.xmin BETWEEN u.longitude - 0.01 AND u.longitude + 0.01
+         AND bbox.ymin BETWEEN u.latitude - 0.01 AND u.latitude + 0.01
+       ORDER BY ST_Distance_Spheroid(
+         ST_Point(ST_X(geometry), ST_Y(geometry))::POINT_2D,
+         ST_Point(u.longitude, u.latitude)::POINT_2D
+       )
+       LIMIT 1
+   ) p;

--- a/skills/duckdb/upstream.json
+++ b/skills/duckdb/upstream.json
@@ -1,0 +1,6 @@
+{
+  "repo": "https://github.com/duckdb/duckdb-skills.git",
+  "ref": "main",
+  "commit": "7feda8e01e22bc0886c86123f3884947e36d8c69",
+  "synced_at": "2026-04-23"
+}


### PR DESCRIPTION
## Summary
- add a new top-level `duckdb` skill that dispatches into nine vendored DuckDB subworkflows
- port the upstream DuckDB skill content into `skills/duckdb/`, convert spatial references to `.rst`, and move the install eval shell script into `scripts/`
- add a scheduled GitHub Actions check that watches the pinned upstream DuckDB commit and opens or closes a tracking issue when it drifts

## Validation
- `bash -n skills/duckdb/install-duckdb/scripts/eval.sh`
- `pixi run validate-skills`
- `git diff --check`