### PR TITLE
[codex] update skill licenses to CC-BY-4.0

### DIFF
--- a/.changes/unreleased/Changed-cc-by-license.yaml
+++ b/.changes/unreleased/Changed-cc-by-license.yaml
@@ -1,0 +1,2 @@
+kind: Changed
+body: Update all skill frontmatter licenses to CC-BY-4.0 and add the CC BY 4.0 license text at the repo root.

--- a/LICENSE-CC-BY-4.0.txt
+++ b/LICENSE-CC-BY-4.0.txt
@@ -1,0 +1,395 @@
+Attribution 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+        wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+        wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution 4.0 International Public License ("Public License"). To the
+extent this Public License may be interpreted as a contract, You are
+granted the Licensed Rights in consideration of Your acceptance of
+these terms and conditions, and the Licensor grants You such rights in
+consideration of benefits the Licensor receives from making the
+Licensed Material available under these terms and conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  d. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  f. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  g. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  h. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  i. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  j. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  k. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material; and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the "Licensor." The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/skills/ansible/SKILL.md
+++ b/skills/ansible/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ansible
-license: MIT
+license: CC-BY-4.0
 description: >-
   Use this skill whenever the user wants to create, modify, debug, or optimise
   Ansible playbooks, roles, inventories, or configuration. Triggers include any

--- a/skills/argo-cd/SKILL.md
+++ b/skills/argo-cd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: argo-cd
-license: MIT
+license: CC-BY-4.0
 description: >-
   Manage ArgoCD configuration, including applications, projects, repositories,
   clusters, and RBAC. Also used to sync and check the health of ArgoCD apps.

--- a/skills/bitwarden/SKILL.md
+++ b/skills/bitwarden/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bitwarden
-license: MIT
+license: CC-BY-4.0
 description: >-
   Manage .env files and development secrets using the Bitwarden personal
   Password Manager CLI (bw). Use when the user asks to store, retrieve, or

--- a/skills/canvas-design/SKILL.md
+++ b/skills/canvas-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: canvas-design
-license: MIT
+license: CC-BY-4.0
 description: >-
   Create beautiful visual art in .png and .pdf documents using design
   philosophy. Use when the user asks to create a poster, piece of art, design,

--- a/skills/cc-agent-teams/SKILL.md
+++ b/skills/cc-agent-teams/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cc-agent-teams
-license: MIT
+license: CC-BY-4.0
 description: >-
   Claude Code agent teams — coordinate multiple independent Claude Code sessions
   working in parallel with shared task lists and inter-agent messaging. Use when

--- a/skills/cc-hooks/SKILL.md
+++ b/skills/cc-hooks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cc-hooks
-license: MIT
+license: CC-BY-4.0
 description: >-
   Create, manage, and debug Claude Code hooks — event-driven scripts that run
   before or after agent actions. Use when the user asks about hooks,

--- a/skills/changie/SKILL.md
+++ b/skills/changie/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: changie
-license: MIT
+license: CC-BY-4.0
 description: >-
   Changelog entry creation with Changie. Use when writing a changelog entry,
   adding a new change fragment, recording what shipped, or following the Keep a

--- a/skills/charm-tui/SKILL.md
+++ b/skills/charm-tui/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: charm-tui
-license: MIT
+license: CC-BY-4.0
 description: >-
   Build terminal user interfaces with the Go Charm ecosystem (Bubbletea v2,
   Bubbles v2, Lip Gloss v2, Fang v2). Use when creating TUI applications,

--- a/skills/conventional-commits/SKILL.md
+++ b/skills/conventional-commits/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: conventional-commits
-license: MIT
+license: CC-BY-4.0
 description: >-
   Provides guidance on writing commit messages using the Conventional Commits
   specification. Trigger this skill when writing commit messages, generating

--- a/skills/csv/SKILL.md
+++ b/skills/csv/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: csv
-license: MIT
+license: CC-BY-4.0
 description: >-
   Use when scanning, updating, validating, or summarising pipe-delimited
   CSV extraction sheets for the scoping review. Also covers converting the Excel

--- a/skills/defuddle/SKILL.md
+++ b/skills/defuddle/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: defuddle
-license: MIT
+license: CC-BY-4.0
 description: >-
   Extract clean markdown content from web pages using Defuddle CLI, removing
   clutter and navigation to save tokens. Use instead of WebFetch when the user

--- a/skills/dispatch/SKILL.md
+++ b/skills/dispatch/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dispatch
-license: MIT
+license: CC-BY-4.0
 description: >-
   Use this skill when the user says "dispatch", "offload", "fan out",
   "fan-out", or asks to route tasks to external coding backends. Also trigger

--- a/skills/document-release/SKILL.md
+++ b/skills/document-release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: document-release
-license: MIT
+license: CC-BY-4.0
 description: >-
   Post-ship documentation update. Use after shipping a feature or at session
   end to ensure README, ARCHITECTURE, CONTRIBUTING, CLAUDE.md, CHANGELOG,

--- a/skills/docx/SKILL.md
+++ b/skills/docx/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docx
-license: MIT
+license: CC-BY-4.0
 description: >-
   Use this skill whenever the user wants to create, read, edit, or manipulate
   Word documents (.docx files). Triggers include: any mention of 'Word doc',

--- a/skills/duckdb/SKILL.md
+++ b/skills/duckdb/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: duckdb
+license: CC-BY-4.0
 description: >-
   Work with DuckDB from the CLI: install or update DuckDB and extensions,
   attach database files, query local or remote data, convert formats, explore

--- a/skills/duckdb/attach-db/SKILL.md
+++ b/skills/duckdb/attach-db/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: attach-db
+license: CC-BY-4.0
 description: Attach a DuckDB database file, inspect its tables and schema, and append an `ATTACH` entry to the shared DuckDB state file used by the sibling query workflow. Use when the user wants to open a `.duckdb` file or make a database available for repeated DuckDB queries.
 ---
 

--- a/skills/duckdb/convert-file/SKILL.md
+++ b/skills/duckdb/convert-file/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: convert-file
+license: CC-BY-4.0
 description: Convert data files between CSV, Parquet, JSON, Excel, GeoJSON, and related formats with DuckDB. Use when the user asks to convert a file, export a dataset, save results in another format, or write binary outputs such as Parquet or XLSX.
 ---
 

--- a/skills/duckdb/duckdb-docs/SKILL.md
+++ b/skills/duckdb/duckdb-docs/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: duckdb-docs
+license: CC-BY-4.0
 description: Search DuckDB and DuckLake documentation and blog posts with a locally cached full-text index. Use when the user asks how DuckDB works, needs official syntax or behavior details, or wants DuckLake-specific documentation.
 ---
 

--- a/skills/duckdb/install-duckdb/SKILL.md
+++ b/skills/duckdb/install-duckdb/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: install-duckdb
+license: CC-BY-4.0
 description: Install or update DuckDB extensions, or update the DuckDB CLI itself when needed. Use when DuckDB is missing, an extension needs to be installed or refreshed, or another DuckDB workflow reports a missing extension.
 ---
 

--- a/skills/duckdb/query/SKILL.md
+++ b/skills/duckdb/query/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: query
+license: CC-BY-4.0
 description: Run SQL against an attached DuckDB database or ad-hoc against files, including natural-language requests that need SQL generation. Use when the user asks a data question, provides DuckDB SQL, or wants to query files with DuckDB.
 ---
 

--- a/skills/duckdb/read-file/SKILL.md
+++ b/skills/duckdb/read-file/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: read-file
+license: CC-BY-4.0
 description: Read data files or remote URLs with DuckDB, including CSV, JSON, Parquet, Avro, Excel, spatial formats, and SQLite files. Use when the user asks what is in a dataset, wants a schema or sample, or needs quick profiling of a data file. Not for source code.
 ---
 

--- a/skills/duckdb/read-memories/SKILL.md
+++ b/skills/duckdb/read-memories/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: read-memories
+license: CC-BY-4.0
 description: Search prior agent session logs stored as JSONL to recover decisions, patterns, or unresolved work. Use when the user references past conversations, asks what was done before, or wants context recovered from local transcript files.
 ---
 

--- a/skills/duckdb/s3-explore/SKILL.md
+++ b/skills/duckdb/s3-explore/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: s3-explore
+license: CC-BY-4.0
 description: Explore and query data on S3, Cloudflare R2, GCS, MinIO, or compatible object storage with DuckDB. Use when the user mentions `s3://`, `r2://`, `gs://`, or `gcs://` URLs, asks what is in a bucket, or wants schema, size, sample, or query results from remote data without downloading it first.
 ---
 

--- a/skills/duckdb/spatial/SKILL.md
+++ b/skills/duckdb/spatial/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: spatial
+license: CC-BY-4.0
 description: Answer spatial-data questions with DuckDB, including coordinate work, distance calculations, spatial joins, containment checks, density analysis, and geographic format conversion. Use when the user mentions maps, locations, coordinates, nearby places, GeoJSON, Shapefile, GeoPackage, GPX, GeoParquet, or Overture Maps data.
 ---
 

--- a/skills/gemini-cli/SKILL.md
+++ b/skills/gemini-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: gemini-cli
-license: MIT
+license: CC-BY-4.0
 description: >-
   Gemini CLI headless dispatch — spawn headless Gemini CLI processes and give
   them jobs. Use when you need to offload web search, parallel research, code

--- a/skills/go-gh/SKILL.md
+++ b/skills/go-gh/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: go-gh
-license: MIT
+license: CC-BY-4.0
 description: >-
   GitHub Actions CI/CD for Go projects. Use when writing or reviewing GitHub
   Actions workflows that build, test, lint, or release Go code — including

--- a/skills/go-naming/SKILL.md
+++ b/skills/go-naming/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: go-naming
-license: MIT
+license: CC-BY-4.0
 description: >-
   Go naming conventions and idiomatic identifier choices. Use when writing new
   Go code, reviewing Go naming decisions, naming packages, types, functions,

--- a/skills/go-secure/SKILL.md
+++ b/skills/go-secure/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: go-secure
-license: MIT
+license: CC-BY-4.0
 description: >-
   Secure Go error handling and information leakage prevention. Use whenever
   writing Go code that handles errors in APIs, services, or any code that

--- a/skills/husky/SKILL.md
+++ b/skills/husky/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: husky
-license: MIT
+license: CC-BY-4.0
 description: >-
   Manage Git hooks with husky v9. Use when the user asks about git hooks
   setup, pre-commit hooks, commit-msg hooks, husky configuration, the

--- a/skills/json-canvas/SKILL.md
+++ b/skills/json-canvas/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: json-canvas
-license: MIT
+license: CC-BY-4.0
 description: >-
   Create and edit JSON Canvas files (.canvas) with nodes, edges, groups, and
   connections. Use when working with .canvas files, creating visual canvases,

--- a/skills/jules-dispatch-creator/SKILL.md
+++ b/skills/jules-dispatch-creator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jules-dispatch-creator
-license: MIT
+license: CC-BY-4.0
 description: >-
   Use when the user wants to set up, add, configure, or adapt Jules GitHub
   Actions dispatch workflows for a repository. Triggers when they say "adapt

--- a/skills/jules/SKILL.md
+++ b/skills/jules/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: jules
-license: MIT
+license: CC-BY-4.0
 description: >-
   Use when dispatching tasks to Jules, creating or monitoring Jules AI coding
   sessions. Also covers approving Jules plans, sending follow-up messages,

--- a/skills/lefthook/SKILL.md
+++ b/skills/lefthook/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lefthook
-license: MIT
+license: CC-BY-4.0
 description: >-
   Git hooks management with Lefthook. Use when writing or reviewing git hook
   configuration for Go projects, polyglot repos, or any project where Node.js

--- a/skills/lychee/SKILL.md
+++ b/skills/lychee/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: lychee
-license: MIT
+license: CC-BY-4.0
 description: >-
   Fast link checker for documentation, READMEs, skills, and any text/markdown files.
   Use when the user asks to "check links", "find broken links", "lint URLs",

--- a/skills/obsidian-bases/SKILL.md
+++ b/skills/obsidian-bases/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: obsidian-bases
-license: MIT
+license: CC-BY-4.0
 description: >-
   Create and edit Obsidian Bases (.base files) with views, filters, formulas,
   and summaries. Use when working with .base files, creating database-like

--- a/skills/obsidian-cli/SKILL.md
+++ b/skills/obsidian-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: obsidian-cli
-license: MIT
+license: CC-BY-4.0
 description: >-
   Interact with Obsidian vaults using the Obsidian CLI to read, create, search,
   and manage notes, tasks, properties, and more. Also supports plugin and theme

--- a/skills/obsidian-markdown/SKILL.md
+++ b/skills/obsidian-markdown/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: obsidian-markdown
-license: MIT
+license: CC-BY-4.0
 description: >-
   Create and edit Obsidian Flavored Markdown with wikilinks, embeds, callouts,
   properties, and other Obsidian-specific syntax. Use when working with .md

--- a/skills/opencode/SKILL.md
+++ b/skills/opencode/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: opencode
-license: MIT
+license: CC-BY-4.0
 description: >-
   Use when interacting with the OpenCode server via its HTTP API. Covers
   starting the server, creating sessions, sending prompts (sync and async),

--- a/skills/pdf/SKILL.md
+++ b/skills/pdf/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pdf
-license: MIT
+license: CC-BY-4.0
 description: >-
   Use when extracting text, tables, or data from PDF files,
   especially academic papers. Also covers converting PDFs to markdown,

--- a/skills/pi-rpc/SKILL.md
+++ b/skills/pi-rpc/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pi-rpc
-license: MIT
+license: CC-BY-4.0
 description: >-
   Pi.dev ConnectRPC service — spawn and manage pi.dev coding agent sessions via
   HTTP/JSON endpoints. Use when dispatching coding tasks to pi.dev, managing

--- a/skills/pixi/SKILL.md
+++ b/skills/pixi/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: pixi
+license: CC-BY-4.0
 description: >-
   Use this skill to help agents manage Python projects, dependencies, environments,
   and builds using the `pixi` package manager. Covers installation, project creation
   (pyproject.toml, workspaces, cross-compilation), managing dependencies, security,
   and migrating from other tools like uv.
-license: MIT
 metadata:
   repo: https://github.com/nq-rdl/agent-skills
 ---

--- a/skills/pre-commit/SKILL.md
+++ b/skills/pre-commit/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: pre-commit
+license: CC-BY-4.0
 description: >-
   Manage Git hooks with Python's pre-commit framework, using pixi. Use when the
   user asks about pre-commit, .pre-commit-config.yaml, Python git hooks, or
   wants to set up linting/formatting hooks via pre-commit.
-license: MIT
 compatibility: >-
   Requires pixi package manager
 metadata:

--- a/skills/quarto-alt-text/SKILL.md
+++ b/skills/quarto-alt-text/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quarto-alt-text
-license: MIT
+license: CC-BY-4.0
 description: >-
   Generate accessible alt text for data visualizations in Quarto documents. Use
   when the user wants to add, improve, or review alt text for figures in .qmd

--- a/skills/quarto-authoring/SKILL.md
+++ b/skills/quarto-authoring/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: quarto-authoring
-license: MIT
+license: CC-BY-4.0
 description: >-
   Writing and authoring Quarto documents (.qmd), including code cell options,
   figure and table captions, cross-references, callout blocks (notes, warnings,

--- a/skills/r-expert/SKILL.md
+++ b/skills/r-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: r-expert
-license: MIT
+license: CC-BY-4.0
 description: >-
   R language expert skill. Use when writing, reviewing, or debugging R code,
   or when the user asks for R best practices, idiomatic R, or guidance on the

--- a/skills/r-lib-cli-app/SKILL.md
+++ b/skills/r-lib-cli-app/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: r-lib-cli-app
-license: MIT
+license: CC-BY-4.0
 description: >-
   Build command-line apps in R using the Rapp package. Use when creating
   a CLI tool in R, adding argument parsing to an R script, turning an R

--- a/skills/r-lib-cli/SKILL.md
+++ b/skills/r-lib-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: r-lib-cli
-license: MIT
+license: CC-BY-4.0
 description: >-
   Comprehensive R package for command-line interface styling, semantic messaging,
   and user communication. Use this skill when working with R code that needs to:

--- a/skills/r-lib-cran-extrachecks/SKILL.md
+++ b/skills/r-lib-cran-extrachecks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: r-lib-cran-extrachecks
-license: MIT
+license: CC-BY-4.0
 description: >-
   Prepare R packages for CRAN submission by checking for common ad-hoc requirements not caught by devtools::check(). Use when: (1) Preparing a package for first CRAN release, (2) Preparing a package update for CRAN resubmission, (3) Reviewing a package to ensure CRAN compliance, (4) Responding to CRAN reviewer feedback. Covers documentation requirements, DESCRIPTION field standards, URL validation, examples, and administrative requirements.
 metadata:

--- a/skills/r-lib-lifecycle/SKILL.md
+++ b/skills/r-lib-lifecycle/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: r-lib-lifecycle
-license: MIT
+license: CC-BY-4.0
 description: >-
   Guidance for managing R package lifecycle according to tidyverse principles
   using the lifecycle package. Use when: (1) Setting up lifecycle

--- a/skills/r-lib-mirai/SKILL.md
+++ b/skills/r-lib-mirai/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: r-lib-mirai
-license: MIT
+license: CC-BY-4.0
 description: >-
   Help users write correct R code for async, parallel, and distributed
   computing using mirai. Use when users need to: run R code asynchronously

--- a/skills/r-lib-package-dev/SKILL.md
+++ b/skills/r-lib-package-dev/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: r-lib-package-dev
-license: MIT
+license: CC-BY-4.0
 description: >-
   Orchestrates the full R package development lifecycle: project creation,
   directory structure, devtools workflow, documentation with roxygen2, code

--- a/skills/r-lib-testing/SKILL.md
+++ b/skills/r-lib-testing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: r-lib-testing
-license: MIT
+license: CC-BY-4.0
 description: >-
   Best practices for writing R package tests using testthat version 3+. Use when writing, organizing, or improving tests for R packages. Covers test structure, expectations, fixtures, snapshots, mocking, and modern testthat 3 patterns including self-sufficient tests, proper cleanup with withr, and snapshot testing.
 metadata:

--- a/skills/report-skill-issue/SKILL.md
+++ b/skills/report-skill-issue/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: report-skill-issue
-license: MIT
+license: CC-BY-4.0
 description: >-
   Report issues with skills to their upstream repository. Use when a skill
   produces errors, unexpected behavior, incorrect output, or fails silently.

--- a/skills/shiny-bslib-theming/SKILL.md
+++ b/skills/shiny-bslib-theming/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shiny-bslib-theming
-license: MIT
+license: CC-BY-4.0
 description: >-
   Advanced theming for Shiny apps using bslib and Bootstrap 5. Use when
   customizing app appearance with bs_theme(), Bootswatch themes, custom

--- a/skills/shiny-bslib/SKILL.md
+++ b/skills/shiny-bslib/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shiny-bslib
-license: MIT
+license: CC-BY-4.0
 description: >-
   Build modern Shiny dashboards and applications using bslib (Bootstrap 5).
   Use when creating new Shiny apps, modernizing legacy apps (fluidPage,

--- a/skills/skill-review/SKILL.md
+++ b/skills/skill-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skill-review
-license: MIT
+license: CC-BY-4.0
 description: >-
   Self-improvement loop for Claude Code skills. Spawns a high-effort Sonnet
   subagent to review the current session and produce actionable bugs and

--- a/skills/sops/SKILL.md
+++ b/skills/sops/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sops
-license: MIT
+license: CC-BY-4.0
 description: >-
   Use when encrypting or decrypting `.env`, `.yaml`, `.json`, or `.ini` secrets
   — even if the user does not say "SOPS" explicitly. Triggers on: storing

--- a/skills/starrocks/SKILL.md
+++ b/skills/starrocks/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: starrocks
-license: MIT
+license: CC-BY-4.0
 description: >-
   StarRocks analytical data warehouse skill. Use when writing or reviewing
   StarRocks SQL, designing tables, choosing partition/bucket strategies,

--- a/skills/stitch-design-md/SKILL.md
+++ b/skills/stitch-design-md/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: stitch-design-md
+license: CC-BY-4.0
 description: >-
   Work with Google Stitch's design.md format. Use this skill when generating UI,
   designing with Stitch, or writing design.md specs. Teaches how to structure the
   spec with concrete examples and validation rules.
-license: MIT
 compatibility: >-
   Requires Google Stitch
 metadata:

--- a/skills/tdd-team-workflow/SKILL.md
+++ b/skills/tdd-team-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tdd-team-workflow
-license: MIT
+license: CC-BY-4.0
 description: >-
   TDD orchestration workflow — drives a red→green→refactor→review cycle by
   delegating each phase to a subagent or any installed dispatch backend. Use

--- a/skills/tdd/SKILL.md
+++ b/skills/tdd/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: tdd
-license: MIT
+license: CC-BY-4.0
 description: >-
   Test-driven development concepts, cycle, and anti-patterns. Load when
   writing or reviewing tests, adding mocks, implementing new behaviour, or

--- a/skills/writerside/SKILL.md
+++ b/skills/writerside/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: writerside
-license: MIT
+license: CC-BY-4.0
 description: >-
   Use when the user asks about Writerside topics, markup tags, documentation
   templates, or building/deploying Writerside projects. Covers semantic XML

--- a/skills/xlsx/SKILL.md
+++ b/skills/xlsx/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: xlsx
-license: MIT
+license: CC-BY-4.0
 description: >-
   Use this skill any time a spreadsheet file is the primary input or output.
   This means any task where the user wants to: open, read, edit, or fix an

--- a/skills/zod/SKILL.md
+++ b/skills/zod/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: zod
-license: MIT
+license: CC-BY-4.0
 description: >-
   Use this skill when defining, validating, or inferring types from data schemas using the Zod library. Useful for input validation, API response checking, and generating TypeScript types from runtime schemas.
 metadata:


### PR DESCRIPTION
## What changed
- update every `skills/**/SKILL.md` frontmatter entry to `license: CC-BY-4.0`
- add `LICENSE-CC-BY-4.0.txt` at the repo root while retaining the existing MIT `LICENSE`
- add a changie fragment for the licensing update

## Why
- standardize skill frontmatter on the new Creative Commons Attribution 4.0 license marker
- ship the full CC BY 4.0 text in-repo so the frontmatter reference has a corresponding root license file
- keep the existing MIT project license in place as an additional repo license, not a replacement

## Impact
- all skill metadata now points to `CC-BY-4.0`
- `.rst` reference files were not modified for license metadata
- the existing MIT license remains untouched

## Validation
- `pixi run validate-skills`
- `git diff --check`
