### PR TITLE
fix(pi-rpc): return assistant output from Prompt and GetMessages

### DIFF
--- a/.changes/unreleased/Fixed-20260426-093514.yaml
+++ b/.changes/unreleased/Fixed-20260426-093514.yaml
@@ -1,0 +1,3 @@
+kind: Fixed
+body: skill:pi-rpc — `Prompt` now populates `PromptResponse.Messages` and `GetMessages` parses the real `pi --mode rpc` nested message wire format, so the rpc layer can return assistant output (#80).
+time: 2026-04-26T09:35:14.254841377+10:00

--- a/skills/pi-rpc/scripts/handler/session_handler.go
+++ b/skills/pi-rpc/scripts/handler/session_handler.go
@@ -187,9 +187,10 @@ func parseMessages(events []session.Event) []*pirpcv1.Message {
 		}
 		var envelope struct {
 			Message struct {
-				Role    string `json:"role"`
-				IsError bool   `json:"is_error"`
-				Content []struct {
+				Role       string `json:"role"`
+				IsError    bool   `json:"is_error"`
+				ToolCallID string `json:"tool_call_id"`
+				Content    []struct {
 					Type string `json:"type"`
 					Text string `json:"text"`
 				} `json:"content"`
@@ -199,7 +200,7 @@ func parseMessages(events []session.Event) []*pirpcv1.Message {
 			continue
 		}
 		msg := envelope.Message
-		if msg.Role == "" {
+		if msg.Role == "" && msg.ToolCallID == "" {
 			continue
 		}
 		var content string
@@ -212,6 +213,7 @@ func parseMessages(events []session.Event) []*pirpcv1.Message {
 			Role:        messageRoleToProto(msg.Role),
 			Content:     content,
 			IsError:     msg.IsError,
+			ToolCallId:  msg.ToolCallID,
 			TimestampMs: evt.Timestamp.UnixMilli(),
 		})
 	}

--- a/skills/pi-rpc/scripts/handler/session_handler.go
+++ b/skills/pi-rpc/scripts/handler/session_handler.go
@@ -68,6 +68,9 @@ func (h *SessionHandler) Prompt(ctx context.Context, req *connect.Request[pirpcv
 		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("session %q not found", req.Msg.SessionId))
 	}
 
+	// Record event count before sending so we can slice events added during this prompt.
+	startIdx := len(s.Events())
+
 	cmd := map[string]string{"type": "prompt", "message": req.Msg.Message}
 	data, _ := json.Marshal(cmd)
 	if err := s.Send(data); err != nil {
@@ -90,8 +93,10 @@ func (h *SessionHandler) Prompt(ctx context.Context, req *connect.Request[pirpcv
 		case <-ticker.C:
 			state := s.State()
 			if state == session.StateIdle || state == session.StateError || state == session.StateTerminated {
+				msgs := parseMessages(s.Events()[startIdx:])
 				return connect.NewResponse(&pirpcv1.PromptResponse{
-					State: stateToProto(state),
+					State:    stateToProto(state),
+					Messages: msgs,
 				}), nil
 			}
 		}
@@ -163,38 +168,54 @@ func (h *SessionHandler) GetMessages(ctx context.Context, req *connect.Request[p
 		return nil, connect.NewError(connect.CodeNotFound, fmt.Errorf("session %q not found", req.Msg.SessionId))
 	}
 
-	// Collect messages from buffered session events.
-	events := s.Events()
+	return connect.NewResponse(&pirpcv1.GetMessagesResponse{
+		Messages: parseMessages(s.Events()),
+	}), nil
+}
+
+// parseMessages extracts proto Messages from a slice of session events.
+// It reads message_end events using the nested wire shape emitted by real pi:
+//
+//	{"type":"message_end","message":{"role":"...","content":[{"type":"text","text":"..."}],...}}
+//
+// Text content is concatenated from all text-type content blocks.
+func parseMessages(events []session.Event) []*pirpcv1.Message {
 	var msgs []*pirpcv1.Message
 	for _, evt := range events {
-		if evt.Type != "message_end" && evt.Type != "message_update" {
+		if evt.Type != "message_end" {
 			continue
 		}
-		var parsed struct {
-			Role       string `json:"role"`
-			Content    string `json:"content"`
-			IsError    bool   `json:"is_error"`
-			ToolCallID string `json:"tool_call_id"`
+		var envelope struct {
+			Message struct {
+				Role    string `json:"role"`
+				IsError bool   `json:"is_error"`
+				Content []struct {
+					Type string `json:"type"`
+					Text string `json:"text"`
+				} `json:"content"`
+			} `json:"message"`
 		}
-		if err := json.Unmarshal(evt.Raw, &parsed); err != nil {
+		if err := json.Unmarshal(evt.Raw, &envelope); err != nil {
 			continue
 		}
-		// message_update events from real pi are streaming deltas with no role/content — skip them.
-		if parsed.Role == "" && parsed.Content == "" && parsed.ToolCallID == "" {
+		msg := envelope.Message
+		if msg.Role == "" {
 			continue
+		}
+		var content string
+		for _, block := range msg.Content {
+			if block.Type == "text" {
+				content += block.Text
+			}
 		}
 		msgs = append(msgs, &pirpcv1.Message{
-			Role:        messageRoleToProto(parsed.Role),
-			Content:     parsed.Content,
-			IsError:     parsed.IsError,
-			ToolCallId:  parsed.ToolCallID,
+			Role:        messageRoleToProto(msg.Role),
+			Content:     content,
+			IsError:     msg.IsError,
 			TimestampMs: evt.Timestamp.UnixMilli(),
 		})
 	}
-
-	return connect.NewResponse(&pirpcv1.GetMessagesResponse{
-		Messages: msgs,
-	}), nil
+	return msgs
 }
 
 func (h *SessionHandler) GetState(ctx context.Context, req *connect.Request[pirpcv1.GetStateRequest]) (*connect.Response[pirpcv1.GetStateResponse], error) {

--- a/skills/pi-rpc/scripts/handler/session_handler_test.go
+++ b/skills/pi-rpc/scripts/handler/session_handler_test.go
@@ -404,3 +404,68 @@ func TestHandlerCreateExplicitOverridesDefaults(t *testing.T) {
 		t.Errorf("model = %q, want %q", stateResp.Msg.Model, "explicit-model")
 	}
 }
+
+// TestHandlerPromptReturnsMessages tests both bugs from issue #80:
+//
+//  1. Prompt must populate PromptResponse.Messages (bug 1: currently always empty).
+//  2. GetMessages must parse the real pi --mode rpc wire format, where the message
+//     is nested under a "message" key, not at the top level (bug 2: flat-struct
+//     parser silently produces empty fields and the empty-skip drops every message).
+//
+// The real_shape fake-pi scenario emits event shapes that exactly match the upstream
+// AgentEvent union (packages/agent/src/types.ts):
+//
+//	message_update: {"type":"message_update","message":{...AgentMessage...},"assistantMessageEvent":{...}}
+//	message_end:    {"type":"message_end","message":{...AgentMessage...}}
+//	agent_end:      {"type":"agent_end","messages":[...AgentMessage...]}
+func TestHandlerPromptReturnsMessages(t *testing.T) {
+	// Arrange
+	t.Setenv("FAKE_PI_SCENARIO", "real_shape")
+	client, cleanup := setupTestServerWithBinary(t, fakePi(t))
+	defer cleanup()
+
+	createResp, err := client.Create(context.Background(), connect.NewRequest(&pirpcv1.CreateRequest{
+		Provider: "anthropic",
+		Model:    "claude-sonnet-4-5",
+		Cwd:      t.TempDir(),
+	}))
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+	sid := createResp.Msg.SessionId
+
+	// Act — synchronous Prompt waits for agent_end before returning
+	promptResp, err := client.Prompt(context.Background(), connect.NewRequest(&pirpcv1.PromptRequest{
+		SessionId: sid,
+		Message:   "hello",
+	}))
+	if err != nil {
+		t.Fatalf("Prompt failed: %v", err)
+	}
+
+	// Assert bug 1: PromptResponse.Messages must be populated
+	if len(promptResp.Msg.Messages) == 0 {
+		t.Fatal("bug 1: PromptResponse.Messages is empty; Prompt handler never populates messages")
+	}
+	gotRole := promptResp.Msg.Messages[0].Role
+	if gotRole != pirpcv1.MessageRole_MESSAGE_ROLE_ASSISTANT {
+		t.Errorf("bug 1: first message role = %v, want ASSISTANT", gotRole)
+	}
+	if promptResp.Msg.Messages[0].Content == "" {
+		t.Error("bug 1: first message content is empty")
+	}
+
+	// Assert bug 2: GetMessages must parse the nested message shape
+	msgsResp, err := client.GetMessages(context.Background(), connect.NewRequest(&pirpcv1.GetMessagesRequest{
+		SessionId: sid,
+	}))
+	if err != nil {
+		t.Fatalf("GetMessages failed: %v", err)
+	}
+	if len(msgsResp.Msg.Messages) == 0 {
+		t.Fatal("bug 2: GetMessages returned no messages; nested message shape not parsed")
+	}
+	if msgsResp.Msg.Messages[0].Content == "" {
+		t.Error("bug 2: GetMessages first message content is empty; text not extracted from nested content array")
+	}
+}

--- a/skills/pi-rpc/scripts/testdata/fake-pi.sh
+++ b/skills/pi-rpc/scripts/testdata/fake-pi.sh
@@ -27,12 +27,12 @@ case "$SCENARIO" in
 
   echo)
     # Emit a full agent lifecycle then echo any stdin prompts back as messages.
-    # message_update uses pi's real delta format; message_end carries the complete message.
+    # message_end uses the nested wire shape matching real pi --mode rpc output.
     echo '{"type":"agent_start"}'
     while IFS= read -r line; do
       MSG=$(echo "$line" | grep -o '"message":"[^"]*"' | sed 's/"message":"//;s/"//')
       echo "{\"type\":\"message_update\",\"delta\":{\"type\":\"text_delta\",\"text\":\"echo: $MSG\"}}"
-      echo "{\"type\":\"message_end\",\"role\":\"assistant\",\"content\":\"echo: $MSG\",\"is_error\":false}"
+      echo "{\"type\":\"message_end\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"echo: $MSG\"}],\"is_error\":false}}"
       echo '{"type":"agent_end"}'
     done
     ;;
@@ -47,6 +47,29 @@ case "$SCENARIO" in
   hang)
     # Start but never emit events — triggers the inactivity watchdog.
     sleep 300
+    ;;
+
+  real_shape)
+    # Emit events matching the real `pi --mode rpc` wire format from upstream
+    # packages/agent/src/types.ts (AgentEvent union).
+    #
+    # Real events wrap the message inside a nested "message" field:
+    #   message_update: { type, message: AgentMessage, assistantMessageEvent: {...} }
+    #   message_end:    { type, message: AgentMessage }
+    #   agent_end:      { type, messages: AgentMessage[] }
+    #
+    # AgentMessage for assistant role (AssistantMessage from @mariozechner/pi-ai types.ts):
+    #   { role, content: [{type:"text",text:...},...], api, provider, model,
+    #     usage: {...}, stopReason, timestamp }
+    echo '{"type":"agent_start"}'
+    while IFS= read -r line; do
+      MSG=$(echo "$line" | grep -o '"message":"[^"]*"' | sed 's/"message":"//;s/"//')
+      # streaming delta: message_update with nested message + assistantMessageEvent
+      echo "{\"type\":\"message_update\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"echo: $MSG\"}],\"api\":\"anthropic-messages\",\"provider\":\"anthropic\",\"model\":\"claude-sonnet-4-5\",\"usage\":{\"input\":10,\"output\":5,\"cacheRead\":0,\"cacheWrite\":0,\"totalTokens\":15,\"cost\":{\"input\":0.001,\"output\":0.002,\"cacheRead\":0,\"cacheWrite\":0,\"total\":0.003}},\"stopReason\":\"stop\",\"timestamp\":1700000000000},\"assistantMessageEvent\":{\"type\":\"text_delta\",\"contentIndex\":0,\"delta\":\"echo: $MSG\",\"partial\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"echo: $MSG\"}],\"api\":\"anthropic-messages\",\"provider\":\"anthropic\",\"model\":\"claude-sonnet-4-5\",\"usage\":{\"input\":10,\"output\":5,\"cacheRead\":0,\"cacheWrite\":0,\"totalTokens\":15,\"cost\":{\"input\":0.001,\"output\":0.002,\"cacheRead\":0,\"cacheWrite\":0,\"total\":0.003}},\"stopReason\":\"stop\",\"timestamp\":1700000000000}}}"
+      # final message_end: nested message, no flat role/content at top level
+      echo "{\"type\":\"message_end\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"echo: $MSG\"}],\"api\":\"anthropic-messages\",\"provider\":\"anthropic\",\"model\":\"claude-sonnet-4-5\",\"usage\":{\"input\":10,\"output\":5,\"cacheRead\":0,\"cacheWrite\":0,\"totalTokens\":15,\"cost\":{\"input\":0.001,\"output\":0.002,\"cacheRead\":0,\"cacheWrite\":0,\"total\":0.003}},\"stopReason\":\"stop\",\"timestamp\":1700000000000}}"
+      echo "{\"type\":\"agent_end\",\"messages\":[{\"role\":\"user\",\"content\":\"$MSG\",\"timestamp\":1700000000000},{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"echo: $MSG\"}],\"api\":\"anthropic-messages\",\"provider\":\"anthropic\",\"model\":\"claude-sonnet-4-5\",\"usage\":{\"input\":10,\"output\":5,\"cacheRead\":0,\"cacheWrite\":0,\"totalTokens\":15,\"cost\":{\"input\":0.001,\"output\":0.002,\"cacheRead\":0,\"cacheWrite\":0,\"total\":0.003}},\"stopReason\":\"stop\",\"timestamp\":1700000000000}]}"
+    done
     ;;
 
   *)

--- a/skills/pi-rpc/scripts/testdata/fake-pi.sh
+++ b/skills/pi-rpc/scripts/testdata/fake-pi.sh
@@ -30,7 +30,7 @@ case "$SCENARIO" in
     # message_end uses the nested wire shape matching real pi --mode rpc output.
     echo '{"type":"agent_start"}'
     while IFS= read -r line; do
-      MSG=$(echo "$line" | grep -o '"message":"[^"]*"' | sed 's/"message":"//;s/"//')
+      MSG=$(echo "$line" | sed -n 's/.*"message":"\([^"]*\)".*/\1/p')
       echo "{\"type\":\"message_update\",\"delta\":{\"type\":\"text_delta\",\"text\":\"echo: $MSG\"}}"
       echo "{\"type\":\"message_end\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"echo: $MSG\"}],\"is_error\":false}}"
       echo '{"type":"agent_end"}'
@@ -63,7 +63,7 @@ case "$SCENARIO" in
     #     usage: {...}, stopReason, timestamp }
     echo '{"type":"agent_start"}'
     while IFS= read -r line; do
-      MSG=$(echo "$line" | grep -o '"message":"[^"]*"' | sed 's/"message":"//;s/"//')
+      MSG=$(echo "$line" | sed -n 's/.*"message":"\([^"]*\)".*/\1/p')
       # streaming delta: message_update with nested message + assistantMessageEvent
       echo "{\"type\":\"message_update\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"echo: $MSG\"}],\"api\":\"anthropic-messages\",\"provider\":\"anthropic\",\"model\":\"claude-sonnet-4-5\",\"usage\":{\"input\":10,\"output\":5,\"cacheRead\":0,\"cacheWrite\":0,\"totalTokens\":15,\"cost\":{\"input\":0.001,\"output\":0.002,\"cacheRead\":0,\"cacheWrite\":0,\"total\":0.003}},\"stopReason\":\"stop\",\"timestamp\":1700000000000},\"assistantMessageEvent\":{\"type\":\"text_delta\",\"contentIndex\":0,\"delta\":\"echo: $MSG\",\"partial\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"echo: $MSG\"}],\"api\":\"anthropic-messages\",\"provider\":\"anthropic\",\"model\":\"claude-sonnet-4-5\",\"usage\":{\"input\":10,\"output\":5,\"cacheRead\":0,\"cacheWrite\":0,\"totalTokens\":15,\"cost\":{\"input\":0.001,\"output\":0.002,\"cacheRead\":0,\"cacheWrite\":0,\"total\":0.003}},\"stopReason\":\"stop\",\"timestamp\":1700000000000}}}"
       # final message_end: nested message, no flat role/content at top level


### PR DESCRIPTION
Two coupled bugs prevented the rpc layer from returning agent output:

1. The `Prompt` handler returned `PromptResponse{State}` only, leaving the protobuf-reserved `Messages` field empty.
2. The `GetMessages` handler parsed `message_end` events using flat `{role, content, is_error}` fields. Real `pi --mode rpc` emits the nested `{message: {role, content: [{type:"text", text:...}]}}` wire shape from upstream `packages/agent/src/types.ts`; the flat parser silently produced empty messages and the empty-skip dropped them.

## Changes

- Extract a single `parseMessages` helper that reads the nested envelope and concatenates text content blocks. `Prompt` now snapshots the event index before sending and slices new events on completion to return the turn's assistant messages. `GetMessages` uses the same helper.
- Update the `echo` `fake-pi.sh` scenario to emit the nested shape so existing tests cover the same parser path real pi exercises.
- Add a `real_shape` scenario emitting the full upstream envelope (api/provider/usage/etc.) for the new `TestHandlerPromptReturnsMessages` regression test.

## Verification

- `go test -race -count=1 ./...` — all PASS
- `go vet ./...`, `gofmt -l .` — clean
- `make build && make lint` — clean
- `pixi run -e default validate-skills` — 55 skills validated

Closes #80