### PR TITLE
feat(pi-rpc): forward system_prompt and append_system_prompt to pi subprocess

### DIFF
--- a/.changes/unreleased/Added-20260426-094307.yaml
+++ b/.changes/unreleased/Added-20260426-094307.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: skill:pi-rpc — `CreateRequest` now accepts `system_prompt` and `append_system_prompt` (repeated) fields, forwarded as `--system-prompt` and `--append-system-prompt` flags to the spawned `pi` subprocess (#92).
+time: 2026-04-26T09:43:07.161664616+10:00

--- a/skills/pi-rpc/SKILL.md
+++ b/skills/pi-rpc/SKILL.md
@@ -95,7 +95,7 @@ All endpoints accept `Content-Type: application/json` POST requests.
 
 | Endpoint | Purpose | Key Fields |
 |----------|---------|------------|
-| `pirpc.v1.SessionService/Create` | Spawn a pi.dev subprocess | `provider` (optional), `model` (optional), `cwd`, `thinking_level` (maps to pi's `--thinking` flag; alternatively use `model:suffix` notation, e.g. `"model":"gpt-5.4:xhigh"`) |
+| `pirpc.v1.SessionService/Create` | Spawn a pi.dev subprocess | `provider` (optional), `model` (optional), `cwd`, `thinking_level` (maps to pi's `--thinking` flag; alternatively use `model:suffix` notation, e.g. `"model":"gpt-5.4:xhigh"`), `system_prompt` (maps to pi's `--system-prompt`; empty = model default), `append_system_prompt` (repeated string; each element maps to one `--append-system-prompt` flag) |
 | `pirpc.v1.SessionService/Prompt` | Send prompt, wait for completion | `session_id`, `message` |
 | `pirpc.v1.SessionService/PromptAsync` | Send prompt, return immediately | `session_id`, `message` |
 | `pirpc.v1.SessionService/StreamEvents` | Server-streaming events | `session_id`, optional `filter` |

--- a/skills/pi-rpc/scripts/gen/pirpc/v1/session.pb.go
+++ b/skills/pi-rpc/scripts/gen/pirpc/v1/session.pb.go
@@ -225,9 +225,16 @@ type CreateRequest struct {
 	// Optional thinking level ("off", "minimal", "low", "medium", "high").
 	ThinkingLevel string `protobuf:"bytes,4,opt,name=thinking_level,json=thinkingLevel,proto3" json:"thinking_level,omitempty"`
 	// Optional session inactivity timeout in seconds.
+	// 0 (default) uses the server default (60s). Negative values are rejected.
 	TimeoutSeconds int32 `protobuf:"varint,5,opt,name=timeout_seconds,json=timeoutSeconds,proto3" json:"timeout_seconds,omitempty"`
-	unknownFields  protoimpl.UnknownFields
-	sizeCache      protoimpl.SizeCache
+	// Override the system prompt for this session.
+	// Maps to pi's --system-prompt flag. Empty string uses the model default.
+	SystemPrompt string `protobuf:"bytes,6,opt,name=system_prompt,json=systemPrompt,proto3" json:"system_prompt,omitempty"`
+	// Additional system-prompt snippets appended after the base system prompt.
+	// Each element maps to one --append-system-prompt flag passed to pi.
+	AppendSystemPrompt []string `protobuf:"bytes,7,rep,name=append_system_prompt,json=appendSystemPrompt,proto3" json:"append_system_prompt,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *CreateRequest) Reset() {
@@ -293,6 +300,20 @@ func (x *CreateRequest) GetTimeoutSeconds() int32 {
 		return x.TimeoutSeconds
 	}
 	return 0
+}
+
+func (x *CreateRequest) GetSystemPrompt() string {
+	if x != nil {
+		return x.SystemPrompt
+	}
+	return ""
+}
+
+func (x *CreateRequest) GetAppendSystemPrompt() []string {
+	if x != nil {
+		return x.AppendSystemPrompt
+	}
+	return nil
 }
 
 type CreateResponse struct {
@@ -1380,13 +1401,15 @@ var File_pirpc_v1_session_proto protoreflect.FileDescriptor
 
 const file_pirpc_v1_session_proto_rawDesc = "" +
 	"\n" +
-	"\x16pirpc/v1/session.proto\x12\bpirpc.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\xa3\x01\n" +
+	"\x16pirpc/v1/session.proto\x12\bpirpc.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\xfa\x01\n" +
 	"\rCreateRequest\x12\x1a\n" +
 	"\bprovider\x18\x01 \x01(\tR\bprovider\x12\x14\n" +
 	"\x05model\x18\x02 \x01(\tR\x05model\x12\x10\n" +
 	"\x03cwd\x18\x03 \x01(\tR\x03cwd\x12%\n" +
 	"\x0ethinking_level\x18\x04 \x01(\tR\rthinkingLevel\x12'\n" +
-	"\x0ftimeout_seconds\x18\x05 \x01(\x05R\x0etimeoutSeconds\"]\n" +
+	"\x0ftimeout_seconds\x18\x05 \x01(\x05R\x0etimeoutSeconds\x12#\n" +
+	"\rsystem_prompt\x18\x06 \x01(\tR\fsystemPrompt\x120\n" +
+	"\x14append_system_prompt\x18\a \x03(\tR\x12appendSystemPrompt\"]\n" +
 	"\x0eCreateResponse\x12\x1d\n" +
 	"\n" +
 	"session_id\x18\x01 \x01(\tR\tsessionId\x12,\n" +

--- a/skills/pi-rpc/scripts/handler/session_handler.go
+++ b/skills/pi-rpc/scripts/handler/session_handler.go
@@ -51,7 +51,15 @@ func (h *SessionHandler) Create(ctx context.Context, req *connect.Request[pirpcv
 	if req.Msg.TimeoutSeconds < 0 {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("timeout_seconds must be non-negative, got %d", req.Msg.TimeoutSeconds))
 	}
-	id, err := h.mgr.Create(ctx, provider, model, req.Msg.Cwd, req.Msg.ThinkingLevel, req.Msg.TimeoutSeconds, req.Msg.SystemPrompt, req.Msg.AppendSystemPrompt)
+	id, err := h.mgr.Create(ctx, session.CreateOpts{
+		Provider:            provider,
+		Model:               model,
+		Cwd:                 req.Msg.Cwd,
+		ThinkingLevel:       req.Msg.ThinkingLevel,
+		TimeoutSeconds:      req.Msg.TimeoutSeconds,
+		SystemPrompt:        req.Msg.SystemPrompt,
+		AppendSystemPrompts: req.Msg.AppendSystemPrompt,
+	})
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("create session: %w", err))
 	}

--- a/skills/pi-rpc/scripts/handler/session_handler.go
+++ b/skills/pi-rpc/scripts/handler/session_handler.go
@@ -51,7 +51,7 @@ func (h *SessionHandler) Create(ctx context.Context, req *connect.Request[pirpcv
 	if req.Msg.TimeoutSeconds < 0 {
 		return nil, connect.NewError(connect.CodeInvalidArgument, fmt.Errorf("timeout_seconds must be non-negative, got %d", req.Msg.TimeoutSeconds))
 	}
-	id, err := h.mgr.Create(ctx, provider, model, req.Msg.Cwd, req.Msg.ThinkingLevel, req.Msg.TimeoutSeconds)
+	id, err := h.mgr.Create(ctx, provider, model, req.Msg.Cwd, req.Msg.ThinkingLevel, req.Msg.TimeoutSeconds, req.Msg.SystemPrompt, req.Msg.AppendSystemPrompt)
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("create session: %w", err))
 	}

--- a/skills/pi-rpc/scripts/handler/session_handler_test.go
+++ b/skills/pi-rpc/scripts/handler/session_handler_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"connectrpc.com/connect"
 	pirpcv1 "github.com/nq-rdl/agent-skills/skills/pi-rpc/scripts/gen/pirpc/v1"
@@ -468,4 +470,64 @@ func TestHandlerPromptReturnsMessages(t *testing.T) {
 	if msgsResp.Msg.Messages[0].Content == "" {
 		t.Error("bug 2: GetMessages first message content is empty; text not extracted from nested content array")
 	}
+}
+
+func TestHandlerCreateForwardsSystemPrompts(t *testing.T) {
+	// Arrange: capture_args scenario writes argv to FAKE_PI_ARGS_FILE
+	argsFile := filepath.Join(t.TempDir(), "pi-args.txt")
+	t.Setenv("FAKE_PI_ARGS_FILE", argsFile)
+	t.Setenv("FAKE_PI_SCENARIO", "capture_args")
+
+	client, cleanup := setupTestServer(t)
+	defer cleanup()
+
+	// Act: create a session with system-prompt fields set
+	_, err := client.Create(context.Background(), connect.NewRequest(&pirpcv1.CreateRequest{
+		Provider:           "anthropic",
+		Model:              "claude-sonnet",
+		Cwd:                t.TempDir(),
+		SystemPrompt:       "You are a SQL reviewer.",
+		AppendSystemPrompt: []string{"Use modern SQL.", "Cite sources."},
+	}))
+	if err != nil {
+		t.Fatalf("Create failed: %v", err)
+	}
+
+	// Assert: wait up to 500ms for the subprocess to write the args file
+	var argv []string
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		data, readErr := os.ReadFile(argsFile)
+		if readErr == nil && len(data) > 0 {
+			for _, line := range strings.Split(strings.TrimRight(string(data), "\n"), "\n") {
+				if line != "" {
+					argv = append(argv, line)
+				}
+			}
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if len(argv) == 0 {
+		t.Fatal("args file was not written by fake-pi subprocess; subprocess may not have received the flags")
+	}
+
+	// --system-prompt must appear as a consecutive pair
+	assertArgPair(t, argv, "--system-prompt", "You are a SQL reviewer.")
+
+	// Each --append-system-prompt entry must appear in order
+	assertArgPair(t, argv, "--append-system-prompt", "Use modern SQL.")
+	assertArgPair(t, argv, "--append-system-prompt", "Cite sources.")
+}
+
+// assertArgPair checks that flag and value appear consecutively in argv.
+func assertArgPair(t *testing.T, argv []string, flag, value string) {
+	t.Helper()
+	for i := 0; i < len(argv)-1; i++ {
+		if argv[i] == flag && argv[i+1] == value {
+			return
+		}
+	}
+	t.Errorf("argv does not contain consecutive pair %q %q\nfull argv: %v", flag, value, argv)
 }

--- a/skills/pi-rpc/scripts/handler/session_handler_test.go
+++ b/skills/pi-rpc/scripts/handler/session_handler_test.go
@@ -493,15 +493,17 @@ func TestHandlerCreateForwardsSystemPrompts(t *testing.T) {
 		t.Fatalf("Create failed: %v", err)
 	}
 
-	// Assert: wait up to 500ms for the subprocess to write the args file
+	// Assert: wait up to 2s for the subprocess to write the args file.
+	// Generous deadline to avoid CI flakiness under -race / cold caches.
+	// Args are null-byte separated so values containing newlines round-trip.
 	var argv []string
-	deadline := time.Now().Add(500 * time.Millisecond)
+	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
 		data, readErr := os.ReadFile(argsFile)
 		if readErr == nil && len(data) > 0 {
-			for _, line := range strings.Split(strings.TrimRight(string(data), "\n"), "\n") {
-				if line != "" {
-					argv = append(argv, line)
+			for _, arg := range strings.Split(string(data), "\x00") {
+				if arg != "" {
+					argv = append(argv, arg)
 				}
 			}
 			break

--- a/skills/pi-rpc/scripts/proto/pirpc/v1/session.proto
+++ b/skills/pi-rpc/scripts/proto/pirpc/v1/session.proto
@@ -67,6 +67,14 @@ message CreateRequest {
   // Optional session inactivity timeout in seconds.
   // 0 (default) uses the server default (60s). Negative values are rejected.
   int32 timeout_seconds = 5;
+
+  // Override the system prompt for this session.
+  // Maps to pi's --system-prompt flag. Empty string uses the model default.
+  string system_prompt = 6;
+
+  // Additional system-prompt snippets appended after the base system prompt.
+  // Each element maps to one --append-system-prompt flag passed to pi.
+  repeated string append_system_prompt = 7;
 }
 
 message CreateResponse {

--- a/skills/pi-rpc/scripts/session/manager.go
+++ b/skills/pi-rpc/scripts/session/manager.go
@@ -34,8 +34,19 @@ func NewManager(binary string) *Manager {
 	}
 }
 
+// CreateOpts bundles the parameters for Manager.Create.
+type CreateOpts struct {
+	Provider            string
+	Model               string
+	Cwd                 string
+	ThinkingLevel       string
+	TimeoutSeconds      int32
+	SystemPrompt        string
+	AppendSystemPrompts []string
+}
+
 // Create spawns a new session subprocess and adds it to the manager.
-func (m *Manager) Create(ctx context.Context, provider, model, cwd, thinkingLevel string, timeoutSeconds int32, systemPrompt string, appendSystemPrompts []string) (string, error) {
+func (m *Manager) Create(ctx context.Context, opts CreateOpts) (string, error) {
 	sessionCtx := context.Background()
 	if ctx != nil {
 		sessionCtx = context.WithoutCancel(ctx)
@@ -45,31 +56,29 @@ func (m *Manager) Create(ctx context.Context, provider, model, cwd, thinkingLeve
 	// Only add pi-specific flags when using the real pi binary
 	if m.binary == "pi" {
 		args = append(args, "--mode", "rpc", "--no-session",
-			"--provider", provider, "--model", model)
-		if thinkingLevel != "" {
-			args = append(args, "--thinking", thinkingLevel)
+			"--provider", opts.Provider, "--model", opts.Model)
+		if opts.ThinkingLevel != "" {
+			args = append(args, "--thinking", opts.ThinkingLevel)
 		}
 	}
 
 	// System-prompt flags are forwarded unconditionally (outside the binary guard)
 	// so that fake-pi can capture them in tests via the capture_args scenario.
-	if systemPrompt != "" || len(appendSystemPrompts) > 0 {
-		if systemPrompt != "" {
-			args = append(args, "--system-prompt", systemPrompt)
-		}
-		for _, s := range appendSystemPrompts {
-			args = append(args, "--append-system-prompt", s)
-		}
+	if opts.SystemPrompt != "" {
+		args = append(args, "--system-prompt", opts.SystemPrompt)
+	}
+	for _, s := range opts.AppendSystemPrompts {
+		args = append(args, "--append-system-prompt", s)
 	}
 
 	s, err := NewSession(sessionCtx, Config{
 		Binary:            m.binary,
 		Args:              args,
-		Provider:          provider,
-		Model:             model,
-		Cwd:               cwd,
-		ThinkingLevel:     thinkingLevel,
-		InactivityTimeout: time.Duration(timeoutSeconds) * time.Second,
+		Provider:          opts.Provider,
+		Model:             opts.Model,
+		Cwd:               opts.Cwd,
+		ThinkingLevel:     opts.ThinkingLevel,
+		InactivityTimeout: time.Duration(opts.TimeoutSeconds) * time.Second,
 	})
 	if err != nil {
 		return "", err
@@ -83,7 +92,7 @@ func (m *Manager) Create(ctx context.Context, provider, model, cwd, thinkingLeve
 		if msg := s.ErrorMessage(); msg != "" {
 			return "", fmt.Errorf("session startup failed: %s", msg)
 		}
-		return "", fmt.Errorf("session exited immediately (provider=%s, model=%s)", provider, model)
+		return "", fmt.Errorf("session exited immediately (provider=%s, model=%s)", opts.Provider, opts.Model)
 	case <-time.After(200 * time.Millisecond):
 		// Subprocess still alive — good.
 	}

--- a/skills/pi-rpc/scripts/session/manager.go
+++ b/skills/pi-rpc/scripts/session/manager.go
@@ -35,7 +35,7 @@ func NewManager(binary string) *Manager {
 }
 
 // Create spawns a new session subprocess and adds it to the manager.
-func (m *Manager) Create(ctx context.Context, provider, model, cwd, thinkingLevel string, timeoutSeconds int32) (string, error) {
+func (m *Manager) Create(ctx context.Context, provider, model, cwd, thinkingLevel string, timeoutSeconds int32, systemPrompt string, appendSystemPrompts []string) (string, error) {
 	sessionCtx := context.Background()
 	if ctx != nil {
 		sessionCtx = context.WithoutCancel(ctx)
@@ -48,6 +48,17 @@ func (m *Manager) Create(ctx context.Context, provider, model, cwd, thinkingLeve
 			"--provider", provider, "--model", model)
 		if thinkingLevel != "" {
 			args = append(args, "--thinking", thinkingLevel)
+		}
+	}
+
+	// System-prompt flags are forwarded unconditionally (outside the binary guard)
+	// so that fake-pi can capture them in tests via the capture_args scenario.
+	if systemPrompt != "" || len(appendSystemPrompts) > 0 {
+		if systemPrompt != "" {
+			args = append(args, "--system-prompt", systemPrompt)
+		}
+		for _, s := range appendSystemPrompts {
+			args = append(args, "--append-system-prompt", s)
 		}
 	}
 

--- a/skills/pi-rpc/scripts/testdata/fake-pi.sh
+++ b/skills/pi-rpc/scripts/testdata/fake-pi.sh
@@ -72,6 +72,15 @@ case "$SCENARIO" in
     done
     ;;
 
+  capture_args)
+    # Write all argv to FAKE_PI_ARGS_FILE (one arg per line) then stay alive.
+    # Used to assert that flags like --system-prompt are forwarded by the handler.
+    if [ -n "${FAKE_PI_ARGS_FILE:-}" ]; then
+      printf '%s\n' "$@" > "$FAKE_PI_ARGS_FILE"
+    fi
+    cat
+    ;;
+
   *)
     echo "Unknown scenario: $SCENARIO" >&2
     exit 1

--- a/skills/pi-rpc/scripts/testdata/fake-pi.sh
+++ b/skills/pi-rpc/scripts/testdata/fake-pi.sh
@@ -73,10 +73,12 @@ case "$SCENARIO" in
     ;;
 
   capture_args)
-    # Write all argv to FAKE_PI_ARGS_FILE (one arg per line) then stay alive.
+    # Write all argv to FAKE_PI_ARGS_FILE (null-byte separated) then stay alive.
+    # Null bytes preserve any embedded newlines inside individual arguments
+    # (e.g. multi-line system prompts).
     # Used to assert that flags like --system-prompt are forwarded by the handler.
     if [ -n "${FAKE_PI_ARGS_FILE:-}" ]; then
-      printf '%s\n' "$@" > "$FAKE_PI_ARGS_FILE"
+      printf '%s\000' "$@" > "$FAKE_PI_ARGS_FILE"
     fi
     cat
     ;;


### PR DESCRIPTION
Add two new fields to `CreateRequest` mirroring pi's first-class CLI flags:

- `system_prompt` (string): replaces the default system prompt
- `append_system_prompt` (repeated string): each element appends one `--append-system-prompt` fragment, in slice order

Both are forwarded to the spawned `pi` subprocess argv. Empty / nil values emit no flags, so existing tests see unchanged argv.

## Changes

- `proto/pirpc/v1/session.proto` — add fields 6 and 7 to `CreateRequest`
- `gen/pirpc/v1/session.pb.go` — regenerated via `make generate`
- `session/manager.go` — extend `Manager.Create` signature; forward flags outside the existing `m.binary == "pi"` guard so fake-pi captures them in tests
- `handler/session_handler.go` — thread fields from `req.Msg` into `mgr.Create`
- `testdata/fake-pi.sh` — add `capture_args` scenario that writes argv to `FAKE_PI_ARGS_FILE`
- `handler/session_handler_test.go` — add `TestHandlerCreateForwardsSystemPrompts` asserting both flags arrive at the subprocess in the correct order
- `SKILL.md` — document the new fields in the endpoint reference table

## Verification

- `go test -race -count=1 ./...` — all PASS
- `go vet ./...`, `gofmt -l .` — clean
- `make build && make lint` — clean
- `pixi run -e default validate-skills` — 55 skills validated

Closes #92