### PR TITLE
docs: dual-license code (MIT) and content (CC BY 4.0)

### DIFF
--- a/.changes/unreleased/Added-20260426-114154.yaml
+++ b/.changes/unreleased/Added-20260426-114154.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Add `LICENSE-CC-BY-4.0` and a README license section clarifying that software is MIT and skill/documentation content is CC BY 4.0
+time: 2026-04-26T11:41:54.193033122+10:00

--- a/LICENSE-CC-BY-4.0
+++ b/LICENSE-CC-BY-4.0
@@ -33,7 +33,7 @@ exhaustive, and do not form part of our licenses.
      material not subject to the license. This includes other CC-
      licensed material, or material used under an exception or
      limitation to copyright. More considerations for licensors:
-        wiki.creativecommons.org/Considerations_for_licensors
+    wiki.creativecommons.org/Considerations_for_licensors
 
      Considerations for the public: By using one of our public
      licenses, a licensor grants the public permission to use the
@@ -50,7 +50,7 @@ exhaustive, and do not form part of our licenses.
      Although not required by our licenses, you are encouraged to
      respect those requests where reasonable. More considerations
      for the public:
-        wiki.creativecommons.org/Considerations_for_licensees
+    wiki.creativecommons.org/Considerations_for_licensees
 
 =======================================================================
 
@@ -378,7 +378,7 @@ Section 8 -- Interpretation.
 Creative Commons is not a party to its public
 licenses. Notwithstanding, Creative Commons may elect to apply one of
 its public licenses to material it publishes and in those instances
-will be considered the "Licensor." The text of the Creative Commons
+will be considered the “Licensor.” The text of the Creative Commons
 public licenses is dedicated to the public domain under the CC0 Public
 Domain Dedication. Except for the limited purpose of indicating that
 material is shared under a Creative Commons public license or as
@@ -393,3 +393,4 @@ the avoidance of doubt, this paragraph does not form part of the
 public licenses.
 
 Creative Commons may be contacted at creativecommons.org.
+

--- a/README.md
+++ b/README.md
@@ -59,3 +59,10 @@ Validate a single skill:
 ```bash
 ref validate skills/<skill-name>
 ```
+
+## License
+
+This repo is **scope-licensed** (not an `OR` dual-license — the license depends on the file, not the user's choice):
+
+- **Software** — `SPDX-License-Identifier: MIT`. Applies to reference tooling and tests (`src/`, `tests/`), repo scripts, build/validation configuration, and any executable code shipped inside a skill (`skills/*/scripts/`). Full text: [LICENSE](LICENSE).
+- **Media** — `SPDX-License-Identifier: CC-BY-4.0`. Applies to skill content (`SKILL.md` and other prose/assets under `skills/`) and authoring documentation (`docs/`). Full text: [LICENSE-CC-BY-4.0](LICENSE-CC-BY-4.0).

--- a/README.md
+++ b/README.md
@@ -64,5 +64,5 @@ ref validate skills/<skill-name>
 
 This repo is **scope-licensed** (not an `OR` dual-license — the license depends on the file, not the user's choice):
 
-- **Software** — `SPDX-License-Identifier: MIT`. Applies to reference tooling and tests (`src/`, `tests/`), repo scripts, build/validation configuration, and any executable code shipped inside a skill (`skills/*/scripts/`). Full text: [LICENSE](LICENSE).
-- **Media** — `SPDX-License-Identifier: CC-BY-4.0`. Applies to skill content (`SKILL.md` and other prose/assets under `skills/`) and authoring documentation (`docs/`). Full text: [LICENSE-CC-BY-4.0](LICENSE-CC-BY-4.0).
+- **Software** — `SPDX-License-Identifier: MIT`. Full text: [LICENSE](LICENSE).
+- **Media** — `SPDX-License-Identifier: CC-BY-4.0`. Full text: [LICENSE-CC-BY-4.0](LICENSE-CC-BY-4.0).


### PR DESCRIPTION
Mirrors the dual-licensing scheme adopted in [`nq-rdl/agent-extensions#79e9fdc`](https://github.com/nq-rdl/agent-extensions/commit/79e9fdc95a30f7880fcab8ba1398a6b15e2dc01f) so this repo's intent is explicit and consistent with its sibling.

## Changes

- Rename `LICENSE-CC-BY-4.0.txt` → `LICENSE-CC-BY-4.0` (no extension, matching the convention used in `agent-extensions` and the SPDX/`licensee` toolchain).
- Replace the file with the canonical text from creativecommons.org (a few whitespace/quote canonicalizations relative to the previous copy; same legal text).
- Add a **License** section to `README.md` describing the scope-license boundary for this repo:
  - **Software** (`src/`, `tests/`, repo scripts, `skills/*/scripts/`) → MIT
  - **Media** (skill `SKILL.md` and prose/assets under `skills/`, plus `docs/`) → CC BY 4.0
- Add a changie fragment describing the change.

## Notes

- This is **scope-licensed**, not an `OR` dual-license — the license depends on the file's path, not the user's choice.
- The MIT `LICENSE` file is unchanged.
- Per-skill `scripts/` directories are intentionally carved out as MIT, since `docs/specification.mdx` already names `scripts/` as a sub-directory of a skill where executable code lives.