### PR TITLE
feat: add `send-pr` skill

### DIFF
--- a/.changes/unreleased/Added-20260426-send-pr.yaml
+++ b/.changes/unreleased/Added-20260426-send-pr.yaml
@@ -1,3 +1,3 @@
 kind: Added
 time: 2026-04-26T00:00:00Z
-body: Adds new `send-pr` skill that delivers on single command for commit, push and raise PR
+body: Adds new `send-pr` skill that delivers a single command to commit, push, and raise a PR

--- a/.changes/unreleased/Added-20260426-send-pr.yaml
+++ b/.changes/unreleased/Added-20260426-send-pr.yaml
@@ -1,3 +1,3 @@
 kind: Added
 time: 2026-04-26T00:00:00Z
-body: Adds new `send-pr` skill that delivers a single command to commit, push, and raise a PR
+body: Adds new `send-pr` skill that delivers a single command to commit, push, raise a PR, and request review

--- a/.changes/unreleased/Added-20260426-send-pr.yaml
+++ b/.changes/unreleased/Added-20260426-send-pr.yaml
@@ -1,2 +1,2 @@
 kind: Added
-body: Add new `send-pr` skill that delivers on single command for commit, push and raise PR.
+body: Adds new `send-pr` skill that delivers on single command for commit, push and raise PR

--- a/.changes/unreleased/Added-20260426-send-pr.yaml
+++ b/.changes/unreleased/Added-20260426-send-pr.yaml
@@ -1,2 +1,3 @@
 kind: Added
+time: 2026-04-26T00:00:00Z
 body: Adds new `send-pr` skill that delivers on single command for commit, push and raise PR

--- a/.changes/unreleased/Added-20260426-send-pr.yaml
+++ b/.changes/unreleased/Added-20260426-send-pr.yaml
@@ -1,0 +1,2 @@
+kind: Added
+body: Add new `send-pr` skill that delivers on single command for commit, push and raise PR.

--- a/.changes/unreleased/Fixed-20260427-204034-send-pr-yaml-keys.yaml
+++ b/.changes/unreleased/Fixed-20260427-204034-send-pr-yaml-keys.yaml
@@ -1,0 +1,2 @@
+kind: Fixed
+body: Remove duplicate keys in YAML frontmatter of send-pr skill

--- a/.changes/unreleased/Fixed-20260427-204034-send-pr-yaml-keys.yaml
+++ b/.changes/unreleased/Fixed-20260427-204034-send-pr-yaml-keys.yaml
@@ -1,2 +1,0 @@
-kind: Fixed
-body: Remove duplicate keys in YAML frontmatter of send-pr skill

--- a/skills/send-pr/SKILL.md
+++ b/skills/send-pr/SKILL.md
@@ -40,7 +40,7 @@ Use Conventional Commits format:
 - First line must be **50 characters or fewer** to avoid GitHub truncation
 - Description should be lowercase, imperative mood ("add feature" not "added feature")
 - Body (if needed) should be wrapped at 72 characters
-- Determine the target branch by checking which of the following exists on the remote, in priority order: `develop`, `main`, `master`. Use the first one found.
+- Determine the target branch by running `gh repo view --json defaultBranchRef -q .defaultBranchRef.name` (or `git symbolic-ref refs/remotes/origin/HEAD` as a fallback), and only resort to checking `develop`, `main`, `master` in that order if both commands fail
 
 ## Pull Request Format
 
@@ -70,7 +70,7 @@ Use this template for the PR body:
 3. Stage all changes with `git add -A`
 4. Commit with the crafted message
 5. Push the branch with `git push -u origin HEAD`
-6. Determine the target branch by checking remote branches (`git branch -r`) for `develop`, `main`, or `master` in that order of priority.
+6. Determine the target (base) branch by running `gh repo view --json defaultBranchRef -q .defaultBranchRef.name`; if that fails, try `git symbolic-ref refs/remotes/origin/HEAD`; only fall back to checking remote branches (`git branch -r`) for `develop`, `main`, or `master` (in that order) if both commands fail.
 7. Create the PR by writing the multi-line PR body to a temporary file (or piping it on stdin) and using `gh pr create --base <target branch> --title "<commit first line>" --body-file <path to PR body file>`
 
 ## Important Notes

--- a/skills/send-pr/SKILL.md
+++ b/skills/send-pr/SKILL.md
@@ -3,9 +3,7 @@ name: send-pr
 license: CC-BY-4.0
 description: >-
   Commits, pushes and raises a PR. Use this skill when the user asks to "ship", "commit, push and raise PR", or similar commands.
-license: CC-BY-4.0
 metadata:
-  repo: REPO
   repo: https://github.com/nq-rdl/agent-skills
   disable-model-invocation: true
 ---

--- a/skills/send-pr/SKILL.md
+++ b/skills/send-pr/SKILL.md
@@ -3,9 +3,9 @@ name: send-pr
 license: CC-BY-4.0
 description: >-
   Commits, pushes and raises a PR. Use this skill when the user asks to "ship", "commit, push and raise PR", or similar commands.
+disable-model-invocation: true
 metadata:
   repo: https://github.com/nq-rdl/agent-skills
-  disable-model-invocation: true
 ---
 
 # Commit, Push and Raise PR
@@ -40,7 +40,6 @@ Use Conventional Commits format:
 - First line must be **50 characters or fewer** to avoid GitHub truncation
 - Description should be lowercase, imperative mood ("add feature" not "added feature")
 - Body (if needed) should be wrapped at 72 characters
-- Determine the target branch by running `gh repo view --json defaultBranchRef -q .defaultBranchRef.name` (or `git symbolic-ref refs/remotes/origin/HEAD` as a fallback), and only resort to checking `develop`, `main`, `master` in that order if both commands fail
 
 ## Pull Request Format
 
@@ -67,11 +66,15 @@ Use this template for the PR body:
 
 1. Run `git status`, `git diff`, and `git diff --staged` to understand all pending changes
 2. Analyse the changes to determine the appropriate commit type and craft a meaningful message
-3. Stage all changes with `git add -A`
+3. Stage files by name (e.g. `git add path/to/file ...`). Avoid `git add -A`/`git add .` unless step 1's review confirms there are no `.env`, credentials, or large binaries that would be swept in
 4. Commit with the crafted message
 5. Push the branch with `git push -u origin HEAD`
-6. Determine the target (base) branch by running `gh repo view --json defaultBranchRef -q .defaultBranchRef.name`; if that fails, try `git symbolic-ref refs/remotes/origin/HEAD`; only fall back to checking remote branches (`git branch -r`) for `develop`, `main`, or `master` (in that order) if both commands fail.
-7. Create the PR by writing the multi-line PR body to a temporary file (or piping it on stdin) and using `gh pr create --base <target branch> --title "<commit first line>" --body-file <path to PR body file>`
+6. Determine the target (base) branch:
+   - Try `gh repo view --json defaultBranchRef -q .defaultBranchRef.name` first
+   - If that fails, run `git symbolic-ref refs/remotes/origin/HEAD | sed 's|^refs/remotes/origin/||'` to derive the plain branch name (the raw `git symbolic-ref` output is `refs/remotes/origin/<branch>` and cannot be passed directly to `gh pr create --base`)
+   - Only if both fail, fall back to checking remote branches (`git branch -r`) for `develop`, `main`, or `master` in that order
+7. Write the PR body to a temporary file, then create the PR with `gh pr create --base <target branch> --title "<commit first line>" --body-file <path to PR body file>`. Clean up the temp file once the PR is created
+8. Ask the user which GitHub login(s) to request a review from, then run `gh pr edit <PR number> --add-reviewer <login>[,<login>...]` (skip if the user declines)
 
 ## Important Notes
 

--- a/skills/send-pr/SKILL.md
+++ b/skills/send-pr/SKILL.md
@@ -71,7 +71,7 @@ Use this template for the PR body:
 4. Commit with the crafted message
 5. Push the branch with `git push -u origin HEAD`
 6. Determine the target branch by checking remote branches (`git branch -r`) for `develop`, `main`, or `master` in that order of priority.
-7. Create the PR using `gh pr create --base <target branch> --title "<commit first line>" --body "<PR body>"`
+7. Create the PR by writing the multi-line PR body to a temporary file (or piping it on stdin) and using `gh pr create --base <target branch> --title "<commit first line>" --body-file <path to PR body file>`
 
 ## Important Notes
 

--- a/skills/send-pr/SKILL.md
+++ b/skills/send-pr/SKILL.md
@@ -69,7 +69,7 @@ Use this template for the PR body:
 4. Commit with the crafted message
 5. Push the branch with `git push -u origin HEAD`
 6. Determine the target branch - `develop`, `main`, or `master` in that order of priority.
-6. Create the PR using `gh pr create --base <target branch> --title "<commit first line>" --body "<PR body>"`
+7. Create the PR using `gh pr create --base <target branch> --title "<commit first line>" --body "<PR body>"`
 
 ## Important Notes
 

--- a/skills/send-pr/SKILL.md
+++ b/skills/send-pr/SKILL.md
@@ -18,6 +18,7 @@ This skill handles the complete workflow of committing staged/unstaged changes, 
 2. **Commit** - Create a well-formed conventional commit
 3. **Push** - Push the current feature branch to origin
 4. **Raise PR** - Create a Pull Request
+5. **Request Review** - Prompt the user for reviewer logins and assign them to the PR
 
 ## Commit Message Format
 
@@ -37,7 +38,7 @@ Use Conventional Commits format:
 - `chore` - maintenance tasks, dependency updates
 
 ### Rules
-- First line must be **50 characters or fewer** to avoid GitHub truncation
+- First line should be **50 characters or fewer** for `git log --oneline` readability (GitHub itself truncates display at ~72; treat 72 as a hard ceiling)
 - Description should be lowercase, imperative mood ("add feature" not "added feature")
 - Body (if needed) should be wrapped at 72 characters
 
@@ -72,9 +73,9 @@ Use this template for the PR body:
 6. Determine the target (base) branch:
    - Try `gh repo view --json defaultBranchRef -q .defaultBranchRef.name` first
    - If that fails, run `git symbolic-ref refs/remotes/origin/HEAD | sed 's|^refs/remotes/origin/||'` to derive the plain branch name (the raw `git symbolic-ref` output is `refs/remotes/origin/<branch>` and cannot be passed directly to `gh pr create --base`)
-   - Only if both fail, fall back to checking remote branches (`git branch -r`) for `develop`, `main`, or `master` in that order
+   - Only if both fail, fall back to scanning remote branches: `git branch -r | sed 's|^[[:space:]]*origin/||' | grep -E '^(develop|main|master)$' | head -1`
 7. Write the PR body to a temporary file, then create the PR with `gh pr create --base <target branch> --title "<commit first line>" --body-file <path to PR body file>`. Clean up the temp file once the PR is created
-8. Ask the user which GitHub login(s) to request a review from, then run `gh pr edit <PR number> --add-reviewer <login>[,<login>...]` (skip if the user declines)
+8. Ask the user which GitHub login(s) to request a review from, then run `gh pr edit --add-reviewer <login>[,<login>...]` (no PR identifier needed — `gh pr edit` resolves it from the current branch; skip if the user declines)
 
 ## Important Notes
 

--- a/skills/send-pr/SKILL.md
+++ b/skills/send-pr/SKILL.md
@@ -1,8 +1,10 @@
 ---
 name: send-pr
+license: CC-BY-4.0
 description: >-
   Commits, pushes and raises a PR. Use this skill when the user asks to "ship", "commit, push and raise PR", or similar commands.
 metadata:
+  repo: https://github.com/nq-rdl/agent-skills
   disable-model-invocation: true
 ---
 
@@ -27,12 +29,12 @@ Use Conventional Commits format:
 ```
 
 ### Types
-- `feat:` - new functionality
-- `fix:` - bug fixes
-- `refactor:` - code restructuring without behaviour change
-- `docs:` - documentation only
-- `test:` - adding or updating tests
-- `chore:` - maintenance tasks, dependency updates
+- `feat` - new functionality
+- `fix` - bug fixes
+- `refactor` - code restructuring without behaviour change
+- `docs` - documentation only
+- `test` - adding or updating tests
+- `chore` - maintenance tasks, dependency updates
 
 ### Rules
 - First line must be **50 characters or fewer** to avoid GitHub truncation
@@ -63,12 +65,12 @@ Use this template for the PR body:
 
 ## Execution Steps
 
-1. Run `git status` and `git diff` to understand all pending changes
+1. Run `git status`, `git diff`, and `git diff --staged` to understand all pending changes
 2. Analyse the changes to determine the appropriate commit type and craft a meaningful message
 3. Stage all changes with `git add -A`
 4. Commit with the crafted message
 5. Push the branch with `git push -u origin HEAD`
-6. Determine the target branch - `develop`, `main`, or `master` in that order of priority.
+6. Determine the target branch by checking remote branches (`git branch -r`) for `develop`, `main`, or `master` in that order of priority.
 7. Create the PR using `gh pr create --base <target branch> --title "<commit first line>" --body "<PR body>"`
 
 ## Important Notes

--- a/skills/send-pr/SKILL.md
+++ b/skills/send-pr/SKILL.md
@@ -3,7 +3,9 @@ name: send-pr
 license: CC-BY-4.0
 description: >-
   Commits, pushes and raises a PR. Use this skill when the user asks to "ship", "commit, push and raise PR", or similar commands.
+license: CC-BY-4.0
 metadata:
+  repo: REPO
   repo: https://github.com/nq-rdl/agent-skills
   disable-model-invocation: true
 ---

--- a/skills/send-pr/SKILL.md
+++ b/skills/send-pr/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: send-pr
+description: >-
+  Commits, pushes and raises a PR. Use this skill when the user asks to "ship", "commit, push and raise PR", or similar commands.
+metadata:
+  disable-model-invocation: true
+---
+
+# Commit, Push and Raise PR
+
+This skill handles the complete workflow of committing staged/unstaged changes, pushing to the remote, and raising a Pull Request.
+
+## Workflow
+
+1. **Analyse Changes** - Review all pending changes (staged and unstaged) to understand the scope and nature of the work
+2. **Commit** - Create a well-formed conventional commit
+3. **Push** - Push the current feature branch to origin
+4. **Raise PR** - Create a Pull Request
+
+## Commit Message Format
+
+Use Conventional Commits format:
+```
+<type>: <description>
+
+[optional body with more detail]
+```
+
+### Types
+- `feat:` - new functionality
+- `fix:` - bug fixes
+- `refactor:` - code restructuring without behaviour change
+- `docs:` - documentation only
+- `test:` - adding or updating tests
+- `chore:` - maintenance tasks, dependency updates
+
+### Rules
+- First line must be **50 characters or fewer** to avoid GitHub truncation
+- Description should be lowercase, imperative mood ("add feature" not "added feature")
+- Body (if needed) should be wrapped at 72 characters
+- Determine the target branch by checking which of the following exists on the remote, in priority order: `develop`, `main`, `master`. Use the first one found.
+
+## Pull Request Format
+
+The PR title should match the first line of the commit message (including the conventional commit prefix).
+
+Use this template for the PR body:
+```markdown
+## Summary
+[2-3 sentences describing what this PR accomplishes and why]
+
+## Changes
+[Bullet points of the key modifications, grouped logically]
+
+## Test Plan
+- [ ] [Specific scenario to verify]
+- [ ] [Another test case]
+- [ ] [Edge case to check]
+
+## Notes for Reviewers
+[Any context that will help reviewers: areas of uncertainty, alternative approaches considered, architectures and patterns worthy of note, or specific files to scrutinise]
+```
+
+## Execution Steps
+
+1. Run `git status` and `git diff` to understand all pending changes
+2. Analyse the changes to determine the appropriate commit type and craft a meaningful message
+3. Stage all changes with `git add -A`
+4. Commit with the crafted message
+5. Push the branch with `git push -u origin HEAD`
+6. Determine the target branch - `develop`, `main`, or `master` in that order of priority.
+6. Create the PR using `gh pr create --base <target branch> --title "<commit first line>" --body "<PR body>"`
+
+## Important Notes
+
+- Derive the commit message and PR content entirely from analysing the actual changes - do not ask the user to describe them
+- The test plan should contain **specific, actionable** test cases derived from the changes, not generic placeholders
+- If changes span multiple concerns and would benefit from separate commits, note this to the user but proceed with a single commit unless instructed otherwise


### PR DESCRIPTION
Add a new `send-pr` skill handling the workflow to commit staged/unstaged changes, push the branch, and raise a Pull Request.

- Adds `skills/send-pr/SKILL.md` specifying the workflow and correct conventional commit / PR body formatting rules.
- Adds `Added` changie fragment to `.changes/unreleased/`.

---
*PR created automatically by Jules for task [10595988250010819676](https://jules.google.com/task/10595988250010819676) started by @rudolfjs*