### PR TITLE
fix: remove duplicate keys in YAML frontmatter of send-pr skill

### DIFF
--- a/.changes/unreleased/Fixed-20260427-204034-send-pr-yaml-keys.yaml
+++ b/.changes/unreleased/Fixed-20260427-204034-send-pr-yaml-keys.yaml
@@ -1,0 +1,2 @@
+kind: Fixed
+body: Remove duplicate keys in YAML frontmatter of send-pr skill

--- a/skills/send-pr/SKILL.md
+++ b/skills/send-pr/SKILL.md
@@ -3,9 +3,7 @@ name: send-pr
 license: CC-BY-4.0
 description: >-
   Commits, pushes and raises a PR. Use this skill when the user asks to "ship", "commit, push and raise PR", or similar commands.
-license: CC-BY-4.0
 metadata:
-  repo: REPO
   repo: https://github.com/nq-rdl/agent-skills
   disable-model-invocation: true
 ---


### PR DESCRIPTION
Fixes a CI failure in the Validate Skills job on this branch.

The failure was caused by duplicate YAML keys in the frontmatter of `skills/send-pr/SKILL.md`:
1. `license: CC-BY-4.0` was present twice.
2. `repo:` was present twice under `metadata`.

This removes the redundant keys so the frontmatter successfully parses and passes `pixi run validate-skills`.

---
*PR created automatically by Jules for task [8802430162142809677](https://jules.google.com/task/8802430162142809677) started by @rudolfjs*