### PR TITLE
feat(gemini-cli): add reasoning-effort / thinking configuration docs

### DIFF
--- a/.changes/unreleased/Added-20260511-195102.yaml
+++ b/.changes/unreleased/Added-20260511-195102.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Document Gemini CLI reasoning effort / thinking budget / thinking level configuration via `modelConfigs` in `settings.json` in the `gemini-cli` skill (#99)
+time: 2026-05-11T19:51:02+10:00

--- a/skills/gemini-cli/SKILL.md
+++ b/skills/gemini-cli/SKILL.md
@@ -9,7 +9,13 @@ description: >-
   when you want to run a task in parallel without consuming your own context
   window, or when the user asks to 'use Gemini', 'search the web with Gemini',
   'dispatch to Gemini', or 'ask Gemini to...'. Also triggers when building
-  automation pipelines that batch-process files through an LLM.
+  automation pipelines that batch-process files through an LLM. Use this skill
+  whenever the user asks to configure Gemini's reasoning effort, thinking
+  budget, or thinking level — phrases like 'set reasoning effort high for
+  gemini', 'configure thinking budget', 'make gemini think harder', or any
+  request to edit .gemini/settings.json modelConfigs / customAliases /
+  overrides — since there is no CLI flag for this and users will not discover
+  it on their own.
 metadata:
   repo: https://github.com/nq-rdl/agent-skills
 ---
@@ -289,8 +295,35 @@ cat large-document.pdf | gemini \
 
 ---
 
+## Reasoning Effort / Thinking Configuration
+
+Gemini's "think harder" knob has **no CLI flag** — it's configured in `.gemini/settings.json` under `modelConfigs`. If a user asks anything like:
+
+- "set reasoning effort high for gemini"
+- "configure thinking budget"
+- "make gemini think harder for the codebaseInvestigator agent"
+- "turn off thinking for gemini-2.5-flash-lite"
+- "what's the gemini equivalent of `reasoning_effort: high`?"
+
+…load `references/reasoning-effort.rst` and walk the user through editing `.gemini/settings.json` (project) or `~/.gemini/settings.json` (user).
+
+**Pick the parameter by model family:**
+
+- Gemini **2.5** (`gemini-2.5-pro`, `-flash`, `-flash-lite`) → `thinkingConfig.thinkingBudget` (integer tokens; `-1` dynamic, `0` off, default `8192`)
+- Gemini **3** (`gemini-3-pro-preview`, `gemini-3-flash-preview`) → `thinkingConfig.thinkingLevel` (`"HIGH"` or `"LOW"` — there is **no** `MEDIUM` in the current build; this is the analog of OpenAI/Anthropic `reasoning_effort`)
+
+**Pick the scope:**
+
+- `customAliases` — redefine an alias to bake the thinking config into a model entry (applies model-wide for every caller).
+- `overrides` with `match.overrideScope` — agent-scoped (e.g. crank thinking only for `codebaseInvestigator`, leave other agents alone).
+
+**Always deep-merge into existing `settings.json`** — never overwrite the whole file. Common neighbouring keys (`general`, `ide`, `security`, `ui`, `mcpServers`) must be preserved. See the reference for a `jq`-based merge recipe.
+
+---
+
 ## Reference Docs
 
 - `references/headless.rst` — Headless mode: output formats, JSONL event schema, exit codes
 - `references/cli-reference.rst` — Full CLI flags reference for headless automation
 - `references/automation.rst` — Shell-level automation patterns (piping, bulk processing, functions)
+- `references/reasoning-effort.rst` — Configuring Gemini's reasoning effort / thinking budget / thinking level via `modelConfigs` in `settings.json`

--- a/skills/gemini-cli/references/reasoning-effort.rst
+++ b/skills/gemini-cli/references/reasoning-effort.rst
@@ -1,0 +1,325 @@
+Gemini Reasoning Effort & Thinking Configuration
+================================================
+
+Gemini exposes its "think harder" knob only through ``settings.json`` — there
+is **no CLI flag** for reasoning effort. That makes it a power-user feature
+most callers miss. This reference covers how to set it cleanly without
+clobbering unrelated configuration.
+
+The knob lives under ``modelConfigs`` in either:
+
+- ``.gemini/settings.json`` — project scope (checked into the repo, applies
+  to anyone running ``gemini`` in that working directory)
+- ``~/.gemini/settings.json`` — user scope (your machine, every project)
+
+Project settings win when both are present.
+
+--------------
+
+Quick Recipes
+-------------
+
+Bump a Gemini 3 model to HIGH reasoning (project scope)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The most common case. Drop this into ``.gemini/settings.json``:
+
+.. code:: json
+
+   {
+     "modelConfigs": {
+       "customAliases": {
+         "gemini-3-pro-preview": {
+           "model": "gemini-3-pro-preview",
+           "generationConfig": {
+             "thinkingConfig": { "thinkingLevel": "HIGH" }
+           }
+         }
+       }
+     }
+   }
+
+Now every ``gemini --model gemini-3-pro-preview ...`` invocation thinks at
+HIGH. No flag needed at the call site.
+
+Crank Gemini 2.5 thinking budget to the max
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Gemini 2.5 uses an integer token budget, not a level. ``-1`` means
+"think as long as you need":
+
+.. code:: json
+
+   {
+     "modelConfigs": {
+       "customAliases": {
+         "gemini-2.5-pro": {
+           "model": "gemini-2.5-pro",
+           "generationConfig": {
+             "thinkingConfig": { "thinkingBudget": -1 }
+           }
+         }
+       }
+     }
+   }
+
+Agent-scoped override (only one agent thinks harder)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When you want a single sub-agent (e.g. ``codebaseInvestigator``) to use HIGH
+without changing the base model behavior, use ``overrides`` with
+``overrideScope``:
+
+.. code:: json
+
+   {
+     "modelConfigs": {
+       "overrides": [
+         {
+           "match": { "overrideScope": "codebaseInvestigator" },
+           "config": {
+             "generationConfig": {
+               "thinkingConfig": { "thinkingLevel": "HIGH" }
+             }
+           }
+         }
+       ]
+     }
+   }
+
+Turn thinking off for fast/cheap calls
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Useful for batch jobs where latency matters more than nuance:
+
+.. code:: json
+
+   {
+     "modelConfigs": {
+       "customAliases": {
+         "gemini-2.5-flash-lite": {
+           "model": "gemini-2.5-flash-lite",
+           "generationConfig": {
+             "thinkingConfig": { "thinkingBudget": 0 }
+           }
+         }
+       }
+     }
+   }
+
+--------------
+
+Which Parameter to Use (Model Family Routing)
+---------------------------------------------
+
+The parameter name depends on the model generation. There is no overlap —
+sending the wrong field is silently ignored.
+
++----------------------------+----------------------------+-------------------------+
+| Model family               | Models                     | Parameter               |
++============================+============================+=========================+
+| Gemini 2.5                 | ``gemini-2.5-pro``,        | ``thinkingBudget``      |
+|                            | ``gemini-2.5-flash``,      | (integer, tokens)       |
+|                            | ``gemini-2.5-flash-lite``  |                         |
++----------------------------+----------------------------+-------------------------+
+| Gemini 3                   | ``gemini-3-pro-preview``,  | ``thinkingLevel``       |
+|                            | ``gemini-3-flash-preview`` | (enum: HIGH / LOW)      |
++----------------------------+----------------------------+-------------------------+
+
+Both live under ``generationConfig.thinkingConfig`` in the per-model config.
+
+``thinkingBudget`` (Gemini 2.5)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Integer token budget for the model's hidden reasoning trace.
+
++---------+----------------------------------------------------------+
+| Value   | Meaning                                                  |
++=========+==========================================================+
+| ``-1``  | Dynamic — model decides, can spend as many tokens as it  |
+|         | needs. Best for hard problems.                           |
++---------+----------------------------------------------------------+
+| ``0``   | Off — disable the thinking step entirely. Fastest,       |
+|         | cheapest, lowest quality for hard tasks.                 |
++---------+----------------------------------------------------------+
+| Other   | Hard cap in tokens. ``8192`` is the default for          |
+|         | ``gemini-2.5-pro``. Pick higher for harder reasoning;    |
+|         | lower to bound cost.                                     |
++---------+----------------------------------------------------------+
+
+``thinkingLevel`` (Gemini 3)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Enum analog of OpenAI / Anthropic ``reasoning_effort``. The current build
+ships only two values — **there is no ``MEDIUM``**.
+
++------------+-------------------------------------------------------+
+| Value      | Meaning                                               |
++============+=======================================================+
+| ``HIGH``   | Spend more compute on reasoning. Use for complex      |
+|            | tasks where quality dominates latency.                |
++------------+-------------------------------------------------------+
+| ``LOW``    | Spend less. Default for most flash-class invocations. |
++------------+-------------------------------------------------------+
+
+--------------
+
+Scope Choices: ``customAliases`` vs ``overrides``
+-------------------------------------------------
+
+Two different ways to apply a thinking config. Pick based on **whose**
+behavior you want to change.
+
+``customAliases`` — redefine the model entry
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Replaces the built-in alias. Every caller that resolves to that alias gets
+the new config. Model-wide.
+
+.. code:: json
+
+   "modelConfigs": {
+     "customAliases": {
+       "gemini-3-pro-preview": { "model": "...", "generationConfig": { ... } }
+     }
+   }
+
+Use when: you want one consistent reasoning policy for a model across all
+agents and call sites in this project.
+
+``overrides`` — match by scope
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A list of ``{ match, config }`` entries. The CLI walks the list and applies
+the first match. The most common selector is ``match.overrideScope``, which
+matches the agent name (e.g. ``codebaseInvestigator``, ``planner``).
+
+.. code:: json
+
+   "modelConfigs": {
+     "overrides": [
+       { "match": { "overrideScope": "codebaseInvestigator" },
+         "config": { "generationConfig": { "thinkingConfig": { "thinkingLevel": "HIGH" } } } }
+     ]
+   }
+
+Use when: you want surgical control — crank thinking for the deep-research
+agent, leave fast utility agents alone.
+
+Overrides win over ``customAliases`` for matched scopes.
+
+--------------
+
+Mapping from OpenAI / Anthropic ``reasoning_effort``
+----------------------------------------------------
+
+If you're porting a config from another provider, here's the cheat sheet:
+
++----------------------+-----------------------------+-----------------------------+
+| ``reasoning_effort`` | Gemini 3 (``thinkingLevel``)| Gemini 2.5                  |
+|                      |                             | (``thinkingBudget``)        |
++======================+=============================+=============================+
+| ``low``              | ``LOW``                     | ``2048`` (or ``0`` for off) |
++----------------------+-----------------------------+-----------------------------+
+| ``medium``           | ``LOW`` (no MEDIUM yet) —   | ``8192`` (the default)      |
+|                      | or pick ``HIGH`` if quality |                             |
+|                      | matters                     |                             |
++----------------------+-----------------------------+-----------------------------+
+| ``high``             | ``HIGH``                    | ``-1`` (dynamic) or         |
+|                      |                             | ``24576``                   |
++----------------------+-----------------------------+-----------------------------+
+
+The medium row is the awkward one — Gemini 3 doesn't have an exact match, so
+choose by intent (latency-sensitive → LOW, quality-sensitive → HIGH).
+
+--------------
+
+Merging Into Existing ``settings.json``
+---------------------------------------
+
+``settings.json`` typically already contains keys like ``general``, ``ide``,
+``security``, ``ui``, and ``mcpServers``. **Deep-merge** the
+``modelConfigs`` block in — don't overwrite the whole file.
+
+Manual edit pattern
+~~~~~~~~~~~~~~~~~~~
+
+1. Read the existing file (``cat .gemini/settings.json`` — or treat as
+   ``{}`` if it doesn't exist; ``mkdir -p .gemini`` first if needed).
+2. Add or merge the ``modelConfigs`` key alongside the existing top-level
+   keys.
+3. Inside ``modelConfigs``, merge ``customAliases`` / ``overrides``
+   sub-keys without dropping existing entries.
+4. Write back atomically.
+
+``jq``-based merge (shell)
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For automation, ``jq`` can deep-merge a snippet without touching unrelated
+keys:
+
+.. code:: bash
+
+   mkdir -p .gemini
+   touch .gemini/settings.json
+
+   # Idempotent: if the file is empty, start from {}; otherwise reuse.
+   EXISTING=$(jq '.' .gemini/settings.json 2>/dev/null || echo '{}')
+
+   # The patch — only the modelConfigs subtree we want to add.
+   PATCH='{
+     "modelConfigs": {
+       "customAliases": {
+         "gemini-3-pro-preview": {
+           "model": "gemini-3-pro-preview",
+           "generationConfig": {
+             "thinkingConfig": { "thinkingLevel": "HIGH" }
+           }
+         }
+       }
+     }
+   }'
+
+   # Deep-merge with `*` (jq recursive merge) and write atomically.
+   jq -s '.[0] * .[1]' <(echo "$EXISTING") <(echo "$PATCH") \
+     > .gemini/settings.json.tmp && \
+     mv .gemini/settings.json.tmp .gemini/settings.json
+
+Two cautions:
+
+- ``jq``'s ``*`` operator merges *objects* recursively but **replaces**
+  arrays. If you're touching the ``overrides`` array, read it, append your
+  entry, write the whole list back — don't expect ``*`` to concatenate.
+- After the merge, validate: ``jq '.modelConfigs' .gemini/settings.json``.
+
+Verifying the config took effect
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+After editing, sanity-check by running a prompt and watching response time.
+Gemini doesn't echo the resolved thinking config back, so:
+
+- A HIGH-reasoning prompt should noticeably take longer than the same
+  prompt with the default.
+- For ``thinkingBudget: 0`` (off), responses to reasoning-heavy prompts
+  should degrade in quality compared to the default ``8192``.
+
+If you suspect the config isn't being picked up, run
+``gemini --output-format stream-json -p "..." --yolo`` and inspect the
+``model`` field in the ``init`` event — it should match the alias whose
+config you edited.
+
+--------------
+
+Where to Look Upstream
+----------------------
+
+In a local Gemini CLI install (paths relative to ``@google/gemini-cli`` in
+``node_modules`` or the global npm prefix):
+
+- ``bundle/docs/cli/generation-settings.md`` — full ``modelConfigs``
+  overview
+- ``bundle/docs/reference/configuration.md`` — reference for
+  ``aliases``, ``customAliases``, and ``overrides``
+- ``bundle/chunk-*.js`` (search for ``DEFAULT_MODEL_CONFIGS``) — the
+  built-in alias table, including the ``ThinkingLevel.HIGH`` example for
+  ``chat-base-3``

--- a/tests/skills/test_gemini_cli_reasoning_effort.py
+++ b/tests/skills/test_gemini_cli_reasoning_effort.py
@@ -1,0 +1,130 @@
+"""Contract tests for the gemini-cli skill's reasoning-effort support (issue #99).
+
+These tests pin down the structural promises of the skill so that future edits
+can't silently drop the reasoning/thinking guidance. They run against the
+checked-in skill files, not synthetic fixtures.
+"""
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL_DIR = REPO_ROOT / "skills" / "gemini-cli"
+REFERENCE_FILE = SKILL_DIR / "references" / "reasoning-effort.rst"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+
+
+@pytest.fixture(scope="module")
+def reference_text() -> str:
+    return REFERENCE_FILE.read_text()
+
+
+@pytest.fixture(scope="module")
+def skill_md_text() -> str:
+    return SKILL_MD.read_text()
+
+
+def test_reference_file_exists():
+    assert REFERENCE_FILE.is_file(), (
+        f"Expected {REFERENCE_FILE.relative_to(REPO_ROOT)} to exist — "
+        "the skill must document Gemini's reasoning/thinking configuration."
+    )
+
+
+def test_reference_uses_rst_format(reference_text: str):
+    # Heuristic: rst files use ==== / ---- underlines under headings, not # markers.
+    assert "====" in reference_text or "----" in reference_text, (
+        "reasoning-effort.rst should use reStructuredText section underlines "
+        "to match the rest of references/ (automation.rst, headless.rst, cli-reference.rst)."
+    )
+
+
+@pytest.mark.parametrize(
+    "concept",
+    [
+        "modelConfigs",
+        "thinkingConfig",
+        "thinkingBudget",
+        "thinkingLevel",
+        "settings.json",
+    ],
+)
+def test_reference_covers_core_concept(reference_text: str, concept: str):
+    assert concept in reference_text, (
+        f"reasoning-effort.rst must mention `{concept}` — it's a load-bearing concept "
+        "for Gemini's reasoning configuration."
+    )
+
+
+@pytest.mark.parametrize("model_id", ["gemini-2.5-pro", "gemini-3-pro-preview"])
+def test_reference_names_both_model_families(reference_text: str, model_id: str):
+    assert model_id in reference_text, (
+        f"reasoning-effort.rst must name `{model_id}` — the parameter choice "
+        "(thinkingBudget vs thinkingLevel) depends on the model family."
+    )
+
+
+@pytest.mark.parametrize("scope", ["customAliases", "overrides"])
+def test_reference_covers_both_scopes(reference_text: str, scope: str):
+    assert scope in reference_text, (
+        f"reasoning-effort.rst must explain `{scope}` — users need to know "
+        "whether to redefine an alias globally or override per-agent."
+    )
+
+
+def test_reference_documents_thinkingbudget_sentinels(reference_text: str):
+    # The integer sentinels for Gemini 2.5 are -1 (dynamic), 0 (off), 8192 (default).
+    for sentinel in ("-1", "8192"):
+        assert sentinel in reference_text, (
+            f"reasoning-effort.rst must document the `{sentinel}` thinkingBudget value."
+        )
+
+
+def test_reference_documents_thinkinglevel_enum(reference_text: str):
+    for level in ("HIGH", "LOW"):
+        assert level in reference_text, (
+            f"reasoning-effort.rst must document the `{level}` thinkingLevel value."
+        )
+
+
+def test_reference_maps_reasoning_effort_concept(reference_text: str):
+    # Users coming from OpenAI/Anthropic will search for `reasoning_effort` — the doc
+    # must bridge that vocabulary to Gemini's `thinkingLevel`.
+    assert "reasoning_effort" in reference_text or "reasoning effort" in reference_text, (
+        "reasoning-effort.rst must reference `reasoning_effort` so users coming from "
+        "OpenAI/Anthropic APIs can find the Gemini equivalent."
+    )
+
+
+def test_reference_warns_about_deep_merge(reference_text: str):
+    # Clobbering unrelated keys (general, ide, security, ui) is the trap; the doc
+    # should explicitly call out merging rather than overwriting.
+    lower = reference_text.lower()
+    assert "merge" in lower, (
+        "reasoning-effort.rst must explain how to merge into existing settings.json "
+        "without clobbering unrelated keys."
+    )
+
+
+def test_skill_md_links_reference(skill_md_text: str):
+    assert "references/reasoning-effort.rst" in skill_md_text, (
+        "SKILL.md must link to references/reasoning-effort.rst so Claude knows "
+        "to load it when reasoning/thinking topics come up."
+    )
+
+
+@pytest.mark.parametrize(
+    "phrase",
+    ["reasoning", "thinking"],
+)
+def test_skill_md_description_includes_trigger_phrase(skill_md_text: str, phrase: str):
+    # Extract the YAML frontmatter description so we don't accidentally match
+    # a body mention that doesn't help triggering.
+    parts = skill_md_text.split("---", 2)
+    assert len(parts) >= 3, "SKILL.md is missing frontmatter"
+    frontmatter = parts[1].lower()
+    assert phrase in frontmatter, (
+        f"SKILL.md frontmatter description must include `{phrase}` so the skill "
+        "triggers on reasoning/thinking-related user prompts."
+    )


### PR DESCRIPTION
## Summary

- Adds `skills/gemini-cli/references/reasoning-effort.rst` covering Gemini's `modelConfigs` block — the *only* surface for configuring reasoning effort, since there's no CLI flag for it.
- Updates `SKILL.md` description with trigger phrases (`reasoning effort`, `thinking budget`, `make gemini think harder`, …) and adds a body section that picks the right parameter by model family (`thinkingBudget` for 2.5, `thinkingLevel` for 3) and the right scope (`customAliases` model-wide vs `overrides` agent-scoped).
- Adds `tests/skills/test_gemini_cli_reasoning_effort.py` — a contract test that pins down the structural promises of the docs (file exists, core concepts present, trigger phrases in description, reference linked) so future edits can't silently drop the model-family routing or deep-merge guidance.

The reference doc is hybrid recipe + reference (copy-paste `settings.json` snippets for the common cases, plus full parameter tables, OpenAI/Anthropic `reasoning_effort` mapping, and a `jq`-based deep-merge recipe that preserves unrelated keys like `general`, `ide`, `security`, `ui`).

Closes #99

## Test plan

- [x] `pixi run -e default test` — 63 passed (45 existing + 18 new)
- [x] `pixi run -e default validate-skills` — 55 skills validated
- [x] `pixi run -e default lint` — clean
- [x] `pixi run -e default format --check` — clean
- [x] `pixi run -e default typecheck` — clean
- [x] Description length verified: 993/1024 chars (within validator limit)
- [x] Changie fragment added (`Added` kind, references #99)