### PR TITLE
chore: add committed .claude/settings.json (skill plugins + model/effort config)

### DIFF
--- a/.changes/unreleased/Added-20260529-233716.yaml
+++ b/.changes/unreleased/Added-20260529-233716.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'Add a committed `.claude/settings.json` for this repo: registers the `claude-plugins-official` marketplace and enables the skill-authoring plugins `skill-creator`, `plugin-dev`, and `superpowers`; sets the default model to Opus with always-on thinking at `xhigh` effort, and `sonnet` for subagents.'
+time: 2026-05-29T23:37:16.414447891+10:00

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "model": "opus",
+  "alwaysThinkingEnabled": true,
+  "effortLevel": "xhigh",
+  "env": {
+    "CLAUDE_CODE_SUBAGENT_MODEL": "sonnet"
+  },
+  "extraKnownMarketplaces": {
+    "claude-plugins-official": {
+      "source": {
+        "source": "github",
+        "repo": "anthropics/claude-plugins-official"
+      },
+      "autoUpdate": true
+    }
+  },
+  "enabledPlugins": {
+    "skill-creator@claude-plugins-official": true,
+    "plugin-dev@claude-plugins-official": true,
+    "superpowers@claude-plugins-official": true
+  }
+}


### PR DESCRIPTION
## What

Adds a committed project-level `.claude/settings.json` for this repo.

### Plugins (skill-authoring toolkit)
Registers the `claude-plugins-official` marketplace and enables three plugins so anyone working on skills in this repo gets the right tooling:
- `skill-creator` — create/modify/measure skills
- `plugin-dev` — skill-development, plugin-validator, skill-reviewer
- `superpowers` — writing-skills, brainstorming, TDD, etc.

### Model / thinking / effort
- `model: opus` — default to Opus
- `alwaysThinkingEnabled: true` — thinking always on
- `effortLevel: xhigh` — highest effort the settings file accepts (see note)
- `env.CLAUDE_CODE_SUBAGENT_MODEL: sonnet` — subagents default to Sonnet

## Notes / known limitations
- **`max` effort is not committable.** Per the [model-config docs](https://code.claude.com/docs/en/model-config#adjust-effort-level), `effortLevel` in a settings file only accepts `low|medium|high|xhigh`; `max` is session-only (or via the `CLAUDE_CODE_EFFORT_LEVEL` env var, which would also force subagents to `max`). We chose `xhigh` to keep it persistent and avoid leaking onto subagents.
- **Subagent effort can't be pinned to `high` globally.** There is no settings field for subagent effort; subagents inherit the session level (`xhigh`) unless a subagent's own frontmatter overrides it. Subagent *model* (`sonnet`) and *thinking* (inherited) are set as requested.
- These model/effort settings are committed, so they apply team-wide and reapply on each launch (a teammate's `/model` choice is overridden at startup). Run `/model` to override per-session.

## Changelog
Added a changie fragment (`Added`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated developer plugin marketplace, enabling new plugins for skill creation, plugin development, and advanced development workflows

* **Chores**
  * Configured environment settings to optimize AI reasoning capabilities and marketplace integration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nq-rdl/agent-skills/pull/110?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->