### PR TITLE
feat(acp): add Agent Client Protocol navigation skill

### DIFF
--- a/.changes/unreleased/Added-20260530-222145-acp-skill.yaml
+++ b/.changes/unreleased/Added-20260530-222145-acp-skill.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: New `acp` skill helps humans and agents navigate and use the Agent Client Protocol — running Claude Code inside editors (#10)
+time: 2026-05-30T22:21:45.602079915+10:00

--- a/skills/acp/SKILL.md
+++ b/skills/acp/SKILL.md
@@ -127,8 +127,8 @@ Core methods (see `references/protocol.rst` for the full set and payloads):
 | Client → Agent | `session/cancel` *(notification)* | Cancel the current turn |
 
 Conventions worth remembering: **file paths are absolute**, **line numbers are
-1-based**, and content reuses MCP's content-block types (text, image, resource),
-so an ACP-literate tool is already half MCP-literate.
+1-based**, and content reuses MCP's content-block types (text, image, audio,
+resource, resource_link), so an ACP-literate tool is already half MCP-literate.
 
 ## Quickstart 1 — Run Claude Code in Zed (the flagship)
 

--- a/skills/acp/SKILL.md
+++ b/skills/acp/SKILL.md
@@ -42,7 +42,7 @@ Two roles, and it is easy to get them backwards:
 - **Agent** = the **coding AI** (Claude Code, Gemini CLI, pi…). It runs as a
   subprocess and does the work.
 
-```
+```text
 ┌─────────────────┐   spawns subprocess    ┌──────────────────┐
 │  CLIENT         │ ─────────────────────▶ │  AGENT           │
 │  (the editor)   │                        │  (the coding AI) │
@@ -97,7 +97,7 @@ each as an agent inside the *same editor*.)
 A session runs through a small, fixed sequence of JSON-RPC calls. Methods named
 `x/y` are namespaced; notifications are one-way (no response).
 
-```
+```text
 1. initialize            Client → Agent   negotiate protocol version + capabilities
    (authenticate)        Client → Agent   only if the agent reports it needs auth
 2. session/new           Client → Agent   start a session (cwd, MCP servers) → sessionId

--- a/skills/acp/SKILL.md
+++ b/skills/acp/SKILL.md
@@ -1,0 +1,208 @@
+---
+name: acp
+license: CC-BY-4.0
+description: >-
+  Agent Client Protocol (ACP) — the open JSON-RPC standard that lets code
+  editors (clients) drive coding agents over stdio, like LSP for AI agents.
+  Use this skill to navigate or use ACP: understand the protocol (initialize,
+  session/new, session/prompt, streamed session/update), run Claude Code as an
+  ACP agent inside editors such as Zed, Neovim, VS Code, or JetBrains, wire up
+  other ACP agents (pi via pi-acp, Gemini CLI, Codex), or pick which
+  editor↔agent pair to connect. Trigger whenever the user mentions ACP, "Agent
+  Client Protocol", running Claude Code or another agent inside an editor,
+  pi-acp, claude-code-acp / claude-agent-acp, agent_servers config, or
+  editor↔agent integration. This is editor↔agent integration — distinct from
+  MCP (agent↔tools) and from driving an agent headlessly over HTTP (see the
+  pi-rpc and opencode skills).
+compatibility: >-
+  Knowledge skill — no dependencies. Following the worked examples needs an ACP
+  client (e.g. Zed) and Node.js for the npx-launched agent adapters.
+metadata:
+  repo: https://github.com/nq-rdl/agent-skills
+---
+
+# Agent Client Protocol (ACP) Skill
+
+A navigation skill for **using** ACP — not building an implementation. It helps
+a human or an agent understand the protocol, find which tools speak it, and wire
+an editor to a coding agent. The headline example is running **Claude Code
+inside an editor** over ACP.
+
+## What ACP Is
+
+The **Agent Client Protocol** standardizes how a code editor talks to a coding
+agent, the same way the **Language Server Protocol (LSP)** standardized how an
+editor talks to a language server. Before ACP, every editor↔agent pairing was a
+bespoke integration; ACP lets any compliant editor drive any compliant agent.
+
+Two roles, and it is easy to get them backwards:
+
+- **Client** = the **editor / IDE** (Zed, Neovim, VS Code…). It owns the UI, the
+  filesystem, and the user's trust. It *launches* the agent.
+- **Agent** = the **coding AI** (Claude Code, Gemini CLI, pi…). It runs as a
+  subprocess and does the work.
+
+```
+┌─────────────────┐   spawns subprocess    ┌──────────────────┐
+│  CLIENT         │ ─────────────────────▶ │  AGENT           │
+│  (the editor)   │                        │  (the coding AI) │
+│  Zed / Neovim   │  ◀── JSON-RPC 2.0 ───▶ │  Claude Code     │
+│  VS Code …      │     over stdin/stdout  │  pi / Gemini …   │
+└─────────────────┘                        └──────────────────┘
+        owns UI, files,                       reads/edits code,
+        permissions, MCP                      calls tools, streams
+                                              progress back
+```
+
+The editor boots the agent on demand and talks to it over the agent's
+**stdin/stdout** using newline-delimited JSON-RPC. This inverts the usual
+chatbot shape: the *editor* is in control and grants the agent access, with the
+user approving sensitive actions.
+
+> **The key insight for "how do I use X with ACP?":** almost no agent speaks ACP
+> natively. A thin **adapter** wraps the agent's own mode and translates it to
+> ACP JSON-RPC over stdio. Claude Code is wrapped by `claude-agent-acp`; pi is
+> wrapped by `pi-acp`. Learn that one pattern and the whole ecosystem makes
+> sense. See `references/agents.rst`.
+
+### ACP vs. MCP vs. driving an agent over HTTP
+
+These get conflated constantly. Keep them straight:
+
+| Protocol / approach | Connects | Use the skill |
+|---------------------|----------|---------------|
+| **ACP** | editor ↔ agent | **this skill** |
+| **MCP** | agent ↔ tools/data | MCP skills |
+| **pi-rpc / opencode HTTP** | one agent driving another *headlessly* over HTTP/JSON | `pi-rpc`, `opencode` |
+
+ACP is about putting an agent behind an editor's UI. If you want one agent to
+dispatch work to another with no editor involved, that is the HTTP-driving case
+— reach for `pi-rpc` or `opencode`, not ACP. (Note: pi and Claude Code are both
+*agents*; "use pi with Claude Code" is not a native ACP topology — you would run
+each as an agent inside the *same editor*.)
+
+## When to Use This Skill
+
+| You want to… | Start at |
+|--------------|----------|
+| Understand what ACP is and how the wire protocol works | this file → `references/protocol.rst` |
+| Run **Claude Code** inside an editor (Zed, Neovim, …) | `references/claude-code.rst` |
+| Wire up **another agent** (pi, Gemini, Codex) | `references/agents.rst` |
+| Connect an agent in a specific **editor / client** | `references/clients.rst` |
+| Copy a complete, working setup | `references/examples.rst` |
+| Build an ACP agent or client from scratch | the SDKs — see [Source Material](#source-material) (this skill is about *using* ACP) |
+
+## The Protocol at a Glance
+
+A session runs through a small, fixed sequence of JSON-RPC calls. Methods named
+`x/y` are namespaced; notifications are one-way (no response).
+
+```
+1. initialize            Client → Agent   negotiate protocol version + capabilities
+   (authenticate)        Client → Agent   only if the agent reports it needs auth
+2. session/new           Client → Agent   start a session (cwd, MCP servers) → sessionId
+   (or session/load)     Client → Agent   resume a prior session
+3. session/prompt        Client → Agent   send the user's turn → blocks until a stopReason
+      session/update     Agent  → Client   *streamed* progress: message chunks, tool
+                                           calls, plan updates, mode changes
+      session/request_permission           Agent asks the user to approve a tool call
+                         Agent  → Client
+   (session/cancel)      Client → Agent   interrupt the running turn
+```
+
+Core methods (see `references/protocol.rst` for the full set and payloads):
+
+| Direction | Method | Purpose |
+|-----------|--------|---------|
+| Client → Agent | `initialize` | Handshake: protocol version + capability negotiation |
+| Client → Agent | `authenticate` | Authenticate if the agent requires it |
+| Client → Agent | `session/new` | Create a session; returns a `sessionId` |
+| Client → Agent | `session/load` | Resume an existing session (optional) |
+| Client → Agent | `session/prompt` | Send a user turn; resolves with a `stopReason` |
+| Client → Agent | `session/set_mode` | Switch agent mode, e.g. ask ↔ code (optional) |
+| Agent → Client | `session/update` *(notification)* | Stream message/tool/plan progress |
+| Agent → Client | `session/request_permission` | Ask the user to approve an action |
+| Agent → Client | `fs/read_text_file`, `fs/write_text_file` | Use the editor's filesystem (optional) |
+| Agent → Client | `terminal/*` | Run commands in the editor's terminal (optional) |
+| Client → Agent | `session/cancel` *(notification)* | Cancel the current turn |
+
+Conventions worth remembering: **file paths are absolute**, **line numbers are
+1-based**, and content reuses MCP's content-block types (text, image, resource),
+so an ACP-literate tool is already half MCP-literate.
+
+## Quickstart 1 — Run Claude Code in Zed (the flagship)
+
+The most common "ACP + Claude Code" workflow: Claude Code becomes an agent in
+Zed's agent panel.
+
+1. Install [Zed](https://zed.dev) and open your project.
+2. Open the agent panel: `cmd-?` (macOS) / `ctrl-?` (Linux).
+3. Click the agent selector and choose **Claude Code**. The first time, Zed
+   auto-installs the adapter (`@agentclientprotocol/claude-agent-acp`, formerly
+   `@zed-industries/claude-code-acp`) and prompts you to sign in to your Claude
+   account.
+4. Start a thread and prompt as usual — edits, tool calls, and permission
+   requests now render in Zed's UI.
+
+No `agent_servers` config is needed for the built-in agents. To point the
+adapter at a specific Claude Code binary, set `CLAUDE_CODE_EXECUTABLE`. Full
+setup, auth, Neovim, and troubleshooting: `references/claude-code.rst`.
+
+## Quickstart 2 — Add any ACP agent (pi example)
+
+Agents that aren't built into your editor are added via the editor's agent
+config. In Zed's `settings.json`:
+
+```json
+{
+  "agent_servers": {
+    "pi": {
+      "type": "custom",
+      "command": "npx",
+      "args": ["-y", "pi-acp"],
+      "env": {}
+    }
+  }
+}
+```
+
+`pi-acp` launches and bridges to `pi --mode rpc` over stdio (needs Node 22+ and
+`pi` installed and configured). Gemini CLI uses `gemini --acp`; Codex uses the
+`codex-acp` adapter. The catalog drifts — the live **ACP Registry** is the
+source of truth. See `references/agents.rst`.
+
+## Quickstart 3 — See the protocol by hand
+
+You can drive an agent yourself to watch the JSON-RPC flow — the fastest way to
+*understand* ACP. Pipe newline-delimited requests into an adapter's stdin and
+read its stdout. A complete, runnable handshake is in `references/examples.rst`.
+
+## Reference Docs
+
+Read these as needed — each is loaded only when you follow the pointer.
+
+- `references/protocol.rst` — The wire protocol: roles, transports, full
+  lifecycle, every method, `session/update` variants, permissions, content
+  blocks, tool calls, filesystem/terminal, modes, slash commands, extensibility.
+- `references/agents.rst` — The adapter pattern and how to launch ACP agents
+  (Claude Code, pi, Gemini CLI, Codex), plus the live registry.
+- `references/clients.rst` — ACP editors/clients (Zed, Neovim, VS Code,
+  JetBrains, Emacs…) and how to connect an agent in each.
+- `references/claude-code.rst` — Flagship deep-dive: Claude Code as an ACP
+  agent — adapters, install, auth, editor setup, capabilities, troubleshooting.
+- `references/examples.rst` — Copy-paste end-to-end setups and a hand-driven
+  raw-stdio session.
+
+## Source Material
+
+Canonical, authoritative references (consult these when facts may have changed —
+the ecosystem moves fast):
+
+- Introduction — https://agentclientprotocol.com/get-started/introduction
+- Architecture — https://agentclientprotocol.com/get-started/architecture
+- Protocol spec (source) — https://github.com/agentclientprotocol/agent-client-protocol/tree/main/docs/protocol
+- Agents directory — https://agentclientprotocol.com/get-started/agents
+- Clients directory — https://agentclientprotocol.com/get-started/clients
+- ACP Registry — https://agentclientprotocol.com/get-started/registry
+- LLM-friendly doc index — https://agentclientprotocol.com/llms.txt
+- Zed external agents — https://zed.dev/docs/ai/external-agents

--- a/skills/acp/references/agents.rst
+++ b/skills/acp/references/agents.rst
@@ -1,0 +1,120 @@
+ACP Agents and the Adapter Pattern
+==================================
+
+This file answers "how do I make agent *X* available over ACP?" The short
+answer is almost always: **run its ACP adapter**. Understand the pattern once
+and every agent looks the same.
+
+.. contents:: Contents
+   :local:
+   :depth: 1
+
+The adapter pattern
+-------------------
+
+Most coding agents were not born speaking ACP. They already had their own
+control surface — a JSON-over-stdio "RPC mode", an SDK, or a CLI. An **ACP
+adapter** is a thin process that:
+
+1. Is launched by the client (editor) as a subprocess.
+2. Speaks **ACP JSON-RPC 2.0 over stdio** to the client.
+3. Drives the underlying agent through its native interface and translates both
+   ways — client requests in, agent events out.
+
+::
+
+   ┌──────────┐  ACP/JSON-RPC   ┌──────────────┐  native mode   ┌──────────┐
+   │ editor   │ ◀────stdio────▶ │  ACP adapter │ ◀────────────▶ │  agent   │
+   │ (client) │                 │  (pi-acp …)  │  (pi --mode    │  engine  │
+   └──────────┘                 └──────────────┘   rpc, SDK…)   └──────────┘
+
+So "does X support ACP?" really means "is there an adapter for X?". Because the
+adapter is just another process the editor spawns, **adding an agent is mostly a
+matter of telling the editor the command to run** (see ``clients.rst``).
+
+How an agent process is launched
+--------------------------------
+
+An ACP agent is any executable that, once started, reads JSON-RPC requests on
+``stdin`` and writes JSON-RPC messages on ``stdout`` (see ``protocol.rst`` for
+the stdio rules). Editors store this as a *command + args + env*. The same
+command is what you would run by hand to drive the protocol yourself
+(``examples.rst``).
+
+Built-in vs. custom agents
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Editors expose agents two ways:
+
+- **Registry / built-in** — the editor knows the agent, installs the adapter for
+  you, and keeps it updated. In Zed these are Claude Agent, Gemini CLI, and
+  Codex. You usually just pick them from a menu.
+- **Custom** — you provide the command yourself. This is how you add anything
+  the editor doesn't bundle (e.g. ``pi-acp``).
+
+Durable examples
+----------------
+
+Commands verified at the time of writing. Package names drift — confirm against
+the registry (below) before quoting them as gospel.
+
+Claude Code
+~~~~~~~~~~~
+
+- **Adapter:** ``@agentclientprotocol/claude-agent-acp`` (formerly
+  ``@zed-industries/claude-code-acp``). Wraps the official Claude Agent SDK.
+- **In Zed:** built-in — choose "Claude Code" / "Claude Agent"; Zed installs and
+  manages the adapter automatically.
+- **Auth:** sign in to your Claude account, or set ``ANTHROPIC_API_KEY``.
+- **Tip:** ``CLAUDE_CODE_EXECUTABLE`` overrides which Claude Code binary the
+  adapter drives.
+- Full deep-dive (auth, Neovim, troubleshooting): ``claude-code.rst``.
+
+pi (pi.dev)
+~~~~~~~~~~~
+
+- **Adapter:** ``pi-acp`` — launch with ``npx -y pi-acp``.
+- **What it does:** spawns ``pi --mode rpc`` and bridges it to ACP over stdio.
+- **Prerequisites:** Node.js 22+, ``pi`` installed globally and configured with a
+  model provider. Optional: ``PI_ACP_ENABLE_EMBEDDED_CONTEXT=true``.
+- **Note:** pi skills surface in the client as ``/skill:<name>`` slash commands;
+  sessions resume on both sides.
+- Custom-agent config: ``command: "npx"``, ``args: ["-y", "pi-acp"]``.
+
+Gemini CLI
+~~~~~~~~~~
+
+- **Launch:** ``gemini --acp`` — Gemini CLI has a built-in ACP mode (no separate
+  adapter package). The flag has shifted across releases; confirm with
+  ``gemini --help`` if it is rejected.
+- **In Zed:** built-in — choose "Gemini CLI".
+
+Codex (OpenAI)
+~~~~~~~~~~~~~~
+
+- **Adapter:** ``codex-acp`` (``github.com/zed-industries/codex-acp``).
+- **In Zed:** built-in — choose "Codex".
+
+Others
+~~~~~~
+
+ACP adoption is broad and growing — Cursor, GitHub Copilot CLI (public preview),
+Goose, Cline, JetBrains Junie, Kimi CLI, Docker cagent, and many more publish
+adapters or native ACP modes. Rather than copy a list that rots, look them up
+live (next section).
+
+The registry is the source of truth
+------------------------------------
+
+The set of agents and their exact launch commands change frequently. When you
+need a current, authoritative answer:
+
+- **ACP Registry** — discover/install agents:
+  https://agentclientprotocol.com/get-started/registry
+- **Agents directory** — every known agent + links:
+  https://agentclientprotocol.com/get-started/agents
+- **LLM-friendly index** — machine-readable doc map:
+  https://agentclientprotocol.com/llms.txt
+
+If a launch command here ever fails, treat these as canonical and update
+accordingly.

--- a/skills/acp/references/claude-code.rst
+++ b/skills/acp/references/claude-code.rst
@@ -1,0 +1,129 @@
+Claude Code as an ACP Agent
+===========================
+
+The headline use of ACP: run **Claude Code inside an editor**. Claude Code
+becomes the *agent*; the editor (Zed, Neovim, …) is the *client*. You get
+Claude Code's engine with the editor's native UI — inline diffs, file
+following, permission prompts, terminals.
+
+.. contents:: Contents
+   :local:
+   :depth: 1
+
+What the adapter is
+-------------------
+
+Claude Code does not speak ACP directly. An adapter built on the **official
+Claude Agent SDK** (which runs Claude Code under the hood) implements the ACP
+agent side and translates to ACP JSON-RPC over stdio. It supports:
+
+- Context ``@``-mentions and images
+- Tool calls with permission requests (``session/request_permission``)
+- "Following" the agent through files as it edits
+- Edit review (diffs surfaced in the editor)
+- TODO lists (surfaced as ``plan`` updates)
+- Interactive and background terminals
+- Custom slash commands
+- Client-provided MCP servers
+
+Packages and naming
+-------------------
+
+The package has been renamed, so you will see more than one name in the wild:
+
+- ``@agentclientprotocol/claude-agent-acp`` — current name (per the adapter's
+  own README badge).
+- ``@zed-industries/claude-code-acp`` — the earlier name; still widely
+  referenced and what Zed's registry has historically installed.
+- ``Xuanwo/acp-claude-code`` — a community implementation.
+
+You rarely type these yourself: in an editor with a registry (Zed) the adapter
+is installed and updated for you. Quote a specific package only after checking
+the registry — see https://agentclientprotocol.com/get-started/registry
+
+Setup in Zed (recommended)
+--------------------------
+
+1. Open your project in Zed.
+2. Open the agent panel: ``cmd-?`` (macOS) / ``ctrl-?`` (Linux).
+3. Click the agent selector (left, in the empty state) or the ``+`` button
+   (top-right) and choose **Claude Code**.
+4. On first use, Zed installs the managed adapter and prompts you to sign in to
+   your Claude account.
+5. Start a thread and prompt. Edits, tool calls, and permission requests now
+   render in Zed.
+
+Zed always uses its **managed** adapter version, even if you have Claude Code
+installed globally. To make the adapter drive a specific Claude Code binary, set
+``CLAUDE_CODE_EXECUTABLE`` for the registry entry:
+
+.. code:: json
+
+   {
+     "agent_servers": {
+       "claude-acp": {
+         "type": "registry",
+         "env": { "CLAUDE_CODE_EXECUTABLE": "/usr/local/bin/claude" }
+       }
+     }
+   }
+
+Docs: https://zed.dev/docs/ai/external-agents and
+https://zed.dev/blog/claude-code-via-acp
+
+Setup in Neovim
+---------------
+
+Use an ACP-capable plugin (``CodeCompanion``, ``avante.nvim``, or
+``agentic.nvim`` — see ``clients.rst``) and register Claude Code as an agent.
+The plugin needs the command that launches the adapter; with Node available that
+is the adapter package run via ``npx`` (confirm the exact package name from the
+registry). Follow the plugin's agent-configuration docs for where the
+``command``/``args``/``env`` go.
+
+Authentication
+--------------
+
+Two paths, same as Claude Code itself:
+
+- **Claude account** — sign in when the editor prompts (uses your Claude
+  subscription).
+- **API key** — set ``ANTHROPIC_API_KEY`` in the agent's ``env``.
+
+If prompts never produce a response, auth is the first suspect (see below).
+
+Capabilities and limits
+------------------------
+
+- The agent runs as an independent process; the editor provides the UI and
+  brokers file/terminal access and permissions.
+- What is available depends on capability negotiation at ``initialize`` — e.g.
+  image input requires the agent's ``promptCapabilities.image`` and the editor
+  sending image content blocks.
+- ACP today is stdio-only in practice (HTTP transport is a draft), so the agent
+  runs locally alongside the editor.
+
+Troubleshooting
+---------------
+
+============================== ============================== ============================================
+Symptom                        Likely cause                   Fix
+============================== ============================== ============================================
+Adapter won't install/start    Node/npm missing or offline    Ensure Node.js + network; check editor logs
+Prompts hang, no response      Auth not completed/expired     Re-sign-in or set ``ANTHROPIC_API_KEY``; restart
+Wrong Claude version runs      Managed adapter, not your CLI  Set ``CLAUDE_CODE_EXECUTABLE`` to your binary
+Garbled / "invalid message"    Agent wrote junk to stdout     A non-ACP write corrupts stdio; inspect stderr
+Tool calls never auto-approve  Permission prompts pending     Approve in the editor, or set its permission policy
+============================== ============================== ============================================
+
+When stuck, read the agent's **stderr** (the editor usually exposes adapter
+logs) — per the protocol, stderr is where the agent is allowed to log, so it is
+the diagnostic channel. See ``examples.rst`` for capturing it directly.
+
+Sources
+-------
+
+- Claude Code in Zed (beta) — https://zed.dev/blog/claude-code-via-acp
+- Claude Agent (ACP) — https://zed.dev/acp/agent/claude-agent
+- Adapter repo — https://github.com/zed-industries/claude-code-acp
+- External agents config — https://zed.dev/docs/ai/external-agents

--- a/skills/acp/references/clients.rst
+++ b/skills/acp/references/clients.rst
@@ -1,0 +1,127 @@
+ACP Clients (Editors) and Connecting an Agent
+=============================================
+
+The **client** is the editor/IDE. It launches the agent, exposes the
+filesystem/terminal, mediates permissions, and renders the agent's streamed
+updates. This file covers what a client provides and how to connect an agent in
+the common editors.
+
+.. contents:: Contents
+   :local:
+   :depth: 1
+
+What the client is responsible for
+----------------------------------
+
+When you "connect an agent", the editor takes on these jobs (see ``protocol.rst``
+for the methods behind each):
+
+- **Spawn** the agent subprocess (command + args + env) and run ``initialize``.
+- **Advertise capabilities** — whether it offers ``fs/*`` and ``terminal/*`` so
+  edits and commands flow through the editor.
+- **Render updates** — turn ``session/update`` notifications into UI (assistant
+  text, tool calls, plans, diffs).
+- **Mediate permissions** — answer ``session/request_permission``, usually by
+  asking the user.
+- **Forward MCP servers** — pass the user's configured MCP tools to the agent.
+
+Zed
+---
+
+Zed has native ACP support and is the reference client. Built-in agents (Claude
+Agent, Gemini CLI, Codex) need no config — open the agent panel (``cmd-?`` /
+``ctrl-?``) and pick one.
+
+To add any other agent, declare it under ``agent_servers`` in ``settings.json``.
+
+**Custom agent** (you supply the command):
+
+.. code:: json
+
+   {
+     "agent_servers": {
+       "pi": {
+         "type": "custom",
+         "command": "npx",
+         "args": ["-y", "pi-acp"],
+         "env": {}
+       }
+     }
+   }
+
+**Registry agent** (Zed installs/updates it; override env if needed):
+
+.. code:: json
+
+   {
+     "agent_servers": {
+       "claude-acp": {
+         "type": "registry",
+         "env": { "CLAUDE_CODE_EXECUTABLE": "/path/to/claude" }
+       }
+     }
+   }
+
+The ``command``/``args``/``env`` triple is the universal shape: it is exactly the
+process the editor spawns to speak ACP over stdio. Docs:
+https://zed.dev/docs/ai/external-agents
+
+Neovim
+------
+
+No native support; use a plugin that implements the ACP client:
+
+- **CodeCompanion** — chat/agent plugin with ACP support.
+- **avante.nvim** (``yetone/avante.nvim``).
+- **agentic.nvim** (``carlos-algms/agentic.nvim``).
+
+Each plugin configures agents with the same idea as Zed — a command to launch
+the adapter — using that plugin's config schema.
+
+VS Code
+-------
+
+Use the **"ACP Client"** extension (by *formulahendry*) from the Marketplace,
+then point it at an agent command. (Note: GitHub Copilot CLI also ships its own
+ACP *agent* mode — that is the agent side, not the client.)
+
+JetBrains IDEs
+--------------
+
+Recent JetBrains IDEs include ACP support through the AI Assistant; connect an
+external agent from the AI Assistant settings. See JetBrains' AI Assistant docs.
+
+Emacs
+-----
+
+Use **agent-shell.el**, which speaks ACP and can drive ACP agents from a shell
+buffer.
+
+Other clients
+-------------
+
+ACP clients also exist for **Obsidian** ("Agent Client" plugin), **Chrome** (an
+ACP extension/PWA), **Unity** (UnityACPClient / Unity Agent Client), and a range
+of CLI/desktop tools (acpx, Nori CLI, Toad, Agent Studio, Jockey, …). The set
+grows quickly — check the clients directory for current options.
+
+Building a client
+-----------------
+
+If you are embedding an agent in your own app rather than using an editor, use a
+language SDK (see below) and optionally a UI component kit:
+
+- **ACP Components** — frontend components for agent UIs.
+- **agent-client-kernel** — Jupyter integration.
+- **stdio Bus** — transport-level routing kernel.
+
+Language SDKs: Python, TypeScript, Java, Kotlin, Rust —
+https://agentclientprotocol.com/libraries/python (swap the trailing segment for
+the language you want). Building is out of scope for this skill, but the SDKs are
+where to start.
+
+The directory is the source of truth
+-------------------------------------
+
+Editor support and plugin names move fast. For a current list:
+https://agentclientprotocol.com/get-started/clients

--- a/skills/acp/references/examples.rst
+++ b/skills/acp/references/examples.rst
@@ -1,0 +1,137 @@
+ACP Worked Examples
+===================
+
+Copy-paste setups, plus a hand-driven session that shows the raw protocol. The
+first two are the realistic day-to-day workflows; the third is the fastest way
+to actually *understand* what flows over the wire.
+
+.. contents:: Contents
+   :local:
+   :depth: 1
+
+Example 1 — Claude Code in Zed
+------------------------------
+
+Claude Code is built into Zed, so there is no config to write:
+
+1. Open your project in Zed.
+2. Open the agent panel: ``cmd-?`` (macOS) / ``ctrl-?`` (Linux).
+3. Agent selector → **Claude Code**. First run installs the managed adapter and
+   prompts you to sign in to your Claude account.
+4. Prompt away — edits and tool calls render inline, with permission prompts.
+
+Optional: pin the adapter to a specific Claude Code binary via ``settings.json``:
+
+.. code:: json
+
+   {
+     "agent_servers": {
+       "claude-acp": {
+         "type": "registry",
+         "env": { "CLAUDE_CODE_EXECUTABLE": "/usr/local/bin/claude" }
+       }
+     }
+   }
+
+Example 2 — pi (pi.dev) in Zed
+------------------------------
+
+pi is not built in, so add it as a custom agent. Prerequisites: Node.js 22+,
+``pi`` installed globally and configured with a model provider.
+
+``settings.json``:
+
+.. code:: json
+
+   {
+     "agent_servers": {
+       "pi": {
+         "type": "custom",
+         "command": "npx",
+         "args": ["-y", "pi-acp"],
+         "env": {}
+       }
+     }
+   }
+
+Then open the agent panel, pick **pi**, and prompt. ``pi-acp`` launches
+``pi --mode rpc`` behind the scenes and bridges it to ACP. pi skills appear as
+``/skill:<name>`` commands.
+
+The same shape works for any agent: set ``command``/``args`` to whatever launches
+its adapter.
+
+Example 3 — drive an agent by hand (raw stdio)
+----------------------------------------------
+
+An ACP agent is just a process that reads JSON-RPC on stdin and writes it on
+stdout. Talking to one yourself demystifies the protocol. We use ``pi-acp``
+because it runs standalone with ``npx`` (any stdio adapter works).
+
+The message sequence (one JSON object per line — newline-delimited, no embedded
+newlines):
+
+.. code:: json
+
+   {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1,"clientCapabilities":{"fs":{"readTextFile":true,"writeTextFile":true},"terminal":true}}}
+   {"jsonrpc":"2.0","id":2,"method":"session/new","params":{"cwd":"/absolute/path/to/project","mcpServers":[]}}
+   {"jsonrpc":"2.0","id":3,"method":"session/prompt","params":{"sessionId":"SESSION_ID_FROM_STEP_2","prompt":[{"type":"text","text":"List the files in this directory and summarize the project."}]}}
+
+What you will see on stdout:
+
+- a response to ``id:1`` with the agent's ``protocolVersion`` + ``agentCapabilities``,
+- a response to ``id:2`` containing the new ``sessionId``,
+- a stream of ``session/update`` notifications (``agent_message_chunk``,
+  ``tool_call``, ``tool_call_update``, ``plan`` …),
+- finally a response to ``id:3`` with ``{ "stopReason": "end_turn" }``.
+
+Because ``session/prompt`` needs the ``sessionId`` from step 2, the simplest way
+to try this is **interactively** — start the agent, then paste the lines one at a
+time, reading each response before sending the next:
+
+.. code:: bash
+
+   # Start the agent; it now reads JSON-RPC on stdin, writes on stdout.
+   npx -y pi-acp
+   # Paste the `initialize` line, press Enter, read the response.
+   # Paste `session/new`, press Enter, copy the sessionId from the response.
+   # Paste `session/prompt` (with that sessionId) and watch the updates stream.
+
+Scripted variant (advanced) — keep stdin open with a coprocess so you can read
+the ``sessionId`` before prompting:
+
+.. code:: bash
+
+   coproc AGENT { npx -y pi-acp; }
+   send() { printf '%s\n' "$1" >&"${AGENT[1]}"; }
+
+   send '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":1,"clientCapabilities":{"fs":{"readTextFile":true,"writeTextFile":true},"terminal":true}}}'
+   read -r line <&"${AGENT[0]}"; echo "init  → $line"
+
+   send '{"jsonrpc":"2.0","id":2,"method":"session/new","params":{"cwd":"'"$PWD"'","mcpServers":[]}}'
+   read -r line <&"${AGENT[0]}"; echo "new   → $line"
+   SID=$(printf '%s' "$line" | jq -r '.result.sessionId')
+
+   send '{"jsonrpc":"2.0","id":3,"method":"session/prompt","params":{"sessionId":"'"$SID"'","prompt":[{"type":"text","text":"List the files here."}]}}'
+   # Read lines until the response to id:3 arrives:
+   while read -r line <&"${AGENT[0]}"; do
+     echo "update→ $line"
+     printf '%s' "$line" | jq -e '.id==3' >/dev/null 2>&1 && break
+   done
+
+These payloads are illustrative — confirm exact fields against the schema:
+https://agentclientprotocol.com/protocol/schema
+
+Example 4 — capture stderr for debugging
+-----------------------------------------
+
+The protocol forbids the agent from writing non-ACP data to stdout, so logs go
+to **stderr**. When an agent misbehaves, split the streams:
+
+.. code:: bash
+
+   npx -y pi-acp 2> acp-agent.log
+   # stdout stays clean for ACP messages; diagnostics land in acp-agent.log
+
+In an editor, the equivalent is the adapter/agent log panel — the first place to
+look when prompts hang or sessions fail.

--- a/skills/acp/references/protocol.rst
+++ b/skills/acp/references/protocol.rst
@@ -42,11 +42,14 @@ JSON-RPC over its pipes:
 - ``stderr`` — the agent may write free-form UTF-8 logs; the client may capture,
   forward, or ignore them.
 
-Messages are newline-delimited (``\n``) and **MUST NOT** contain embedded
-newlines. The agent **MUST NOT** write anything to ``stdout`` that is not a valid
-ACP message — debug output goes to ``stderr``. This is the single most common
-cause of a broken agent: a stray ``console.log``/``print`` to stdout corrupts the
-stream.
+Messages are newline-delimited (``\n``): each JSON-RPC message is serialized as a
+single physical line, so the encoded JSON **MUST NOT** contain a literal newline
+between fields. JSON string *values* may still carry newlines as escaped ``\n``
+(or ``\u000a``) — you don't strip newlines from message content, you just keep the
+whole message on one line. The agent **MUST NOT** write anything to ``stdout``
+that is not a valid ACP message — debug output goes to ``stderr``. This is the
+single most common cause of a broken agent: a stray ``console.log``/``print`` to
+stdout corrupts the stream.
 
 **HTTP / WebSocket.** Streamable HTTP is a *draft proposal, in discussion* — not
 yet specified. Treat stdio as the only stable transport today. Implementers may

--- a/skills/acp/references/protocol.rst
+++ b/skills/acp/references/protocol.rst
@@ -1,0 +1,283 @@
+ACP Wire Protocol Reference
+===========================
+
+The Agent Client Protocol is JSON-RPC 2.0 between a **Client** (the editor) and
+an **Agent** (the coding AI). This file distills the normative spec at
+https://agentclientprotocol.com/protocol/overview for *using* and *reasoning
+about* ACP. For the exhaustive type definitions, see the schema:
+https://agentclientprotocol.com/protocol/schema
+
+.. contents:: Contents
+   :local:
+   :depth: 1
+
+Roles and conventions
+---------------------
+
+- **Client** — the editor/IDE. Launches the agent, owns the filesystem and
+  terminal, renders updates, and decides what the agent may do.
+- **Agent** — the coding AI subprocess. Does the work and reports progress.
+
+Two message kinds (JSON-RPC 2.0):
+
+- **Method** — a request expecting a response (result or error).
+- **Notification** — one-way, no response.
+
+Conventions that hold everywhere:
+
+- File paths **MUST** be absolute.
+- Line numbers are **1-based**.
+- Text shown to users defaults to Markdown.
+- Content blocks reuse MCP's representations (text, image, audio, resource), so
+  ACP and MCP share a vocabulary.
+
+Transports
+----------
+
+**stdio (primary).** The client spawns the agent as a subprocess and speaks
+JSON-RPC over its pipes:
+
+- ``stdin`` — the client writes ACP messages to the agent here.
+- ``stdout`` — the agent writes ACP messages to the client here.
+- ``stderr`` — the agent may write free-form UTF-8 logs; the client may capture,
+  forward, or ignore them.
+
+Messages are newline-delimited (``\n``) and **MUST NOT** contain embedded
+newlines. The agent **MUST NOT** write anything to ``stdout`` that is not a valid
+ACP message — debug output goes to ``stderr``. This is the single most common
+cause of a broken agent: a stray ``console.log``/``print`` to stdout corrupts the
+stream.
+
+**HTTP / WebSocket.** Streamable HTTP is a *draft proposal, in discussion* — not
+yet specified. Treat stdio as the only stable transport today. Implementers may
+define custom transports as long as JSON-RPC framing and message lifecycle are
+preserved.
+
+The prompt turn
+---------------
+
+The whole protocol orbits one loop. After setup, a *prompt turn* is: the client
+sends one user turn, the agent streams progress, and the call resolves with a
+reason it stopped.
+
+::
+
+   initialize                    Client → Agent   negotiate version + capabilities
+   [authenticate]                Client → Agent   only if the agent requires it
+   session/new | session/load    Client → Agent   obtain a sessionId
+   ─── prompt turn (repeats) ──────────────────────────────────────────────
+   session/prompt                Client → Agent   send the user's turn
+     session/update  ……………………    Agent  → Client   streamed: text, tools, plan
+     session/request_permission  Agent  → Client   approve a tool call?
+       fs/* and terminal/*       Agent  → Client   use the editor's resources
+   → returns { stopReason }      Agent  → Client   turn ends
+   [session/cancel]              Client → Agent   interrupt (notification)
+
+Method reference
+----------------
+
+Agent methods (Client → Agent)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+==================== ========= ==================================================
+Method               Required  Purpose
+==================== ========= ==================================================
+``initialize``       yes       Handshake; negotiate protocol version + caps
+``authenticate``     yes\*     Authenticate using a method the agent advertised
+``session/new``      yes       Create a session; returns ``sessionId``
+``session/prompt``   yes       Run one user turn; resolves with ``stopReason``
+``session/load``     optional  Resume a prior session (if ``loadSession`` cap)
+``session/set_mode`` optional  Switch agent mode (e.g. ask ↔ code)
+==================== ========= ==================================================
+
+\* ``authenticate`` is only exchanged when the agent returns ``authMethods`` and
+the client is not already authenticated.
+
+Client methods (Agent → Client)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+============================= ========= =========================================
+Method                        Required  Purpose
+============================= ========= =========================================
+``session/request_permission`` yes      Ask the user to approve an action
+``fs/read_text_file``         optional  Read a file via the editor
+``fs/write_text_file``        optional  Write a file via the editor
+``terminal/create``           optional  Start a command in the editor's terminal
+``terminal/output``           optional  Read current output of a terminal
+``terminal/wait_for_exit``    optional  Await terminal exit
+``terminal/kill``             optional  Kill a terminal command
+``terminal/release``          optional  Release terminal resources
+============================= ========= =========================================
+
+Notifications
+~~~~~~~~~~~~~
+
+==================== =============== =============================================
+Notification         Direction       Purpose
+==================== =============== =============================================
+``session/update``   Agent → Client  Stream turn progress (see variants below)
+``session/cancel``   Client → Agent  Cancel the in-flight prompt turn
+==================== =============== =============================================
+
+initialize
+----------
+
+The client opens with ``initialize`` to agree on a protocol version and discover
+capabilities. ``protocolVersion`` is a single **integer** (the latest each side
+supports), not a semver string.
+
+.. code:: json
+
+   // Client → Agent
+   {
+     "protocolVersion": 1,
+     "clientCapabilities": {
+       "fs": { "readTextFile": true, "writeTextFile": true },
+       "terminal": true
+     },
+     "clientInfo": { "name": "zed", "version": "0.x" }
+   }
+
+.. code:: json
+
+   // Agent → Client
+   {
+     "protocolVersion": 1,
+     "agentCapabilities": {
+       "loadSession": true,
+       "promptCapabilities": { "image": true, "audio": false, "embeddedContext": true },
+       "mcpCapabilities": { "http": true, "sse": false }
+     },
+     "agentInfo": { "name": "claude-code", "version": "x.y" },
+     "authMethods": []
+   }
+
+Each side **MUST** only use features the other advertised. Client and agent
+**MUST** agree on a protocol version before any session setup.
+
+Sessions
+--------
+
+- ``session/new`` — create a session. The client passes the working directory
+  (``cwd``, absolute) and any MCP servers the agent should connect to. Returns a
+  ``sessionId`` used by every later call.
+- ``session/load`` — resume a previous session by id (only if the agent reported
+  ``loadSession``). The agent replays history via ``session/update`` before
+  responding.
+
+session/prompt and stop reasons
+-------------------------------
+
+``session/prompt`` carries the user's turn as an array of content blocks and
+**blocks until the turn ends**, then resolves with a ``stopReason``:
+
+============================ ===================================================
+``stopReason``               Meaning
+============================ ===================================================
+``end_turn``                 Model finished without requesting more tools
+``max_tokens``               Token limit reached
+``max_turn_requests``        Too many model requests in one turn
+``refusal``                  Agent declined to continue
+``cancelled``                Client sent ``session/cancel``
+============================ ===================================================
+
+While the turn runs, the agent emits ``session/update`` notifications. The
+client may interrupt at any time with the ``session/cancel`` notification; the
+turn then resolves with ``stopReason: "cancelled"``.
+
+session/update variants
+-----------------------
+
+Every ``session/update`` carries a ``sessionUpdate`` discriminator naming the
+payload shape:
+
+========================== ====================================================
+``sessionUpdate``          Payload
+========================== ====================================================
+``agent_message_chunk``    Incremental assistant text (the visible reply)
+``agent_thought_chunk``    Incremental reasoning/thinking text
+``tool_call``              A new tool invocation (id, title, kind, status)
+``tool_call_update``       Changed fields of an existing tool call
+``plan``                   The agent's task plan (entries: content/priority/status)
+``available_commands_update`` The set of slash commands the agent offers
+``current_mode_update``    The agent's active mode changed
+========================== ====================================================
+
+Permissions
+-----------
+
+When the agent wants to do something requiring consent (e.g. run a command, edit
+a file), it calls ``session/request_permission`` with the proposed tool call and
+a set of options. The client surfaces this to the user (or auto-answers by
+policy) and returns the chosen option. This is the trust hinge of ACP: the agent
+proposes, the client/user disposes.
+
+Content blocks
+--------------
+
+Prompts and updates carry typed content blocks, mirroring MCP:
+
+- ``text`` — Markdown text.
+- ``image`` / ``audio`` — base64 media (gated by ``promptCapabilities``).
+- ``resource`` — embedded resource contents (gated by ``embeddedContext``).
+- ``resource_link`` — a reference to a resource by URI.
+
+Tool calls
+----------
+
+A tool call reports something the agent is doing. Fields:
+
+- ``toolCallId`` (required) — unique within the session.
+- ``title`` (required) — human-readable description.
+- ``kind`` — one of ``read``, ``edit``, ``delete``, ``move``, ``search``,
+  ``execute``, ``think``, ``fetch``, ``other``.
+- ``status`` — ``pending`` → ``in_progress`` → ``completed`` | ``failed``
+  (defaults to ``pending``).
+- ``content`` — output produced; ``locations`` — affected file paths;
+  ``rawInput`` / ``rawOutput`` — raw tool I/O.
+
+The first report uses ``sessionUpdate: "tool_call"``. Subsequent
+``tool_call_update`` notifications send **only changed fields** (``toolCallId``
+plus whatever moved). ``locations`` lets the editor "follow along" — e.g. jump to
+the file the agent is editing.
+
+Filesystem and terminal (client-provided)
+-----------------------------------------
+
+Rather than touching disk directly, an agent can ask the editor to act, so edits
+flow through the editor's buffers, undo history, and permission model:
+
+- ``fs/read_text_file`` / ``fs/write_text_file`` — read/write through the editor
+  (honors unsaved buffers). Gated by ``clientCapabilities.fs``.
+- ``terminal/create`` → ``terminal/output`` / ``terminal/wait_for_exit`` →
+  ``terminal/kill`` → ``terminal/release`` — run commands in the editor's
+  terminal with live output. Gated by ``clientCapabilities.terminal``.
+
+Session modes and slash commands
+--------------------------------
+
+- **Modes** — an agent may expose modes (e.g. *ask* vs *code*); the client
+  switches with ``session/set_mode`` and learns of changes via
+  ``current_mode_update``. See https://agentclientprotocol.com/protocol/session-modes
+- **Slash commands** — an agent advertises commands (e.g. ``/test``) via
+  ``available_commands_update``; the client shows them to the user. See
+  https://agentclientprotocol.com/protocol/slash-commands
+
+Extensibility
+-------------
+
+ACP is designed to extend without forking:
+
+- ``_meta`` fields may be attached to most objects for implementation-specific
+  data.
+- Custom methods/notifications use an underscore prefix (e.g. ``_myorg/foo``).
+
+Unknown ``_``-prefixed fields and methods must be tolerated. See
+https://agentclientprotocol.com/protocol/extensibility
+
+Full schema
+-----------
+
+The complete, authoritative type definitions (every request, response, and
+notification) live in the schema document — consult it when you need an exact
+field: https://agentclientprotocol.com/protocol/schema

--- a/skills/acp/references/protocol.rst
+++ b/skills/acp/references/protocol.rst
@@ -28,8 +28,8 @@ Conventions that hold everywhere:
 - File paths **MUST** be absolute.
 - Line numbers are **1-based**.
 - Text shown to users defaults to Markdown.
-- Content blocks reuse MCP's representations (text, image, audio, resource), so
-  ACP and MCP share a vocabulary.
+- Content blocks reuse MCP's representations (text, image, audio, resource,
+  resource_link), so ACP and MCP share a vocabulary.
 
 Transports
 ----------
@@ -129,9 +129,10 @@ The client opens with ``initialize`` to agree on a protocol version and discover
 capabilities. ``protocolVersion`` is a single **integer** (the latest each side
 supports), not a semver string.
 
+*Client → Agent:*
+
 .. code:: json
 
-   // Client → Agent
    {
      "protocolVersion": 1,
      "clientCapabilities": {
@@ -141,9 +142,10 @@ supports), not a semver string.
      "clientInfo": { "name": "zed", "version": "0.x" }
    }
 
+*Agent → Client:*
+
 .. code:: json
 
-   // Agent → Client
    {
      "protocolVersion": 1,
      "agentCapabilities": {


### PR DESCRIPTION
## Summary

Adds the `acp` skill — a navigation/usage guide for the **Agent Client Protocol (ACP)**, the JSON-RPC standard that lets editors (*clients*) drive coding agents (*agents*) over stdio, like LSP for AI agents.

Scope is **use/navigate ACP, not build it**. The flagship example is running **Claude Code as an ACP agent inside editors** (Zed, Neovim, …).

## Contents

- `SKILL.md` — navigation hub: client/agent mental model, ACP-vs-MCP-vs-HTTP boundary, protocol-at-a-glance, an "I want to…" routing table, and three quickstarts.
- `references/protocol.rst` — wire protocol: roles, transports, lifecycle, every method, `session/update` variants, permissions, content blocks, tool calls.
- `references/agents.rst` — the **adapter pattern** plus verified launch commands (Claude Code, pi, Gemini CLI, Codex) and a pointer to the live ACP registry.
- `references/clients.rst` — ACP editors/clients (Zed, Neovim, VS Code, JetBrains, Emacs) and how to connect an agent in each.
- `references/claude-code.rst` — flagship deep-dive: Claude Code as an ACP agent (adapter, auth, editor setup, troubleshooting).
- `references/examples.rst` — copy-paste setups and a hand-driven raw-stdio session.

## Validation

- `ref validate skills/acp` → **Valid**; `validate-skills` → **56 skills OK**
- All 19 embedded URLs return **HTTP 200**
- Launch commands and payloads verified against primary sources (`gemini --acp`, `session/new` and `session/prompt` shapes, the `claude-agent-acp` package rename)

Closes #10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced the Agent Client Protocol (ACP) skill to help editors/IDEs integrate and interact with ACP-capable agents.

* **Documentation**
  * Added comprehensive ACP docs: protocol specification, agent adapter and registry guidance, Claude Code agent instructions, client integration guides for multiple editors, quickstart paths, worked examples, troubleshooting, and reference material.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nq-rdl/agent-skills/pull/114?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->