### PR TITLE
feat(rust-explain): add skill for reading and navigating Rust code

### DIFF
--- a/.changes/unreleased/Added-20260530-231251.yaml
+++ b/.changes/unreleased/Added-20260530-231251.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'Add rust-explain skill: a teaching assistant for reading and navigating Rust code, with references for the reading vocabulary, numeric/scientific idioms, and tooling.'
+time: 2026-05-30T23:12:51.960617117+10:00

--- a/docs/skill-creation/skills-registry.mdx
+++ b/docs/skill-creation/skills-registry.mdx
@@ -41,6 +41,7 @@ Skills with no `scripts/` directory are pure prompt skills (SKILL.md + optional 
 | `r-lib-package-dev` | — | R package development workflow |
 | `r-lib-testing` | — | Testing R packages (testthat, snapshot tests) |
 | `report-skill-issue` | — | Report issues with skills |
+| `rust-explain` | — | Reading and navigating Rust code — vocabulary, numeric idioms, tooling, trust boundary |
 | `shiny-bslib` | — | Shiny apps with bslib components |
 | `shiny-bslib-theming` | — | bslib theming for Shiny apps |
 | `skill-review` | — | Self-improvement loop for Claude Code skills |

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -66,6 +66,12 @@ RDL uses [nq-rdl/agent-extensions](https://github.com/nq-rdl/agent-extensions) t
 |-------|-------------|
 | [r-expert](../skills/r-expert/) | R language expert — writing, reviewing, and debugging R code with idiomatic best practices. |
 
+### Rust Language
+
+| Skill | Description |
+|-------|-------------|
+| [rust-explain](../skills/rust-explain/) | Teaching assistant for reading and navigating Rust code — reading vocabulary, numeric/scientific idioms, tooling, and the compile/trust boundary. |
+
 ## Frontmatter Specification
 
 All skills follow the [agentskills.io spec](https://agentskills.io/specification). Required fields:

--- a/skills/rust-explain/SKILL.md
+++ b/skills/rust-explain/SKILL.md
@@ -65,12 +65,13 @@ Pick the mode that fits the request:
    in reading order.
 2. **Why does / doesn't this compile** — build borrow-checker intuition.
    *Compile* the snippet to surface the real diagnostic — no need to run it —
-   then pair that message with what the rule protects against. For unfamiliar
-   code, prefer `rustc` on the single file: `cargo check`/`cargo clippy` compile
-   the whole crate, which *runs* its `build.rs` and proc-macros at check time —
-   untrusted code executes even though you never run the binary. Reserve
-   actually executing the code for when the reader asks about runtime behavior.
-   See `references/tooling.rst` (it carries the full trust-boundary note).
+   then pair that message with what the rule protects against. Prefer `rustc` on
+   the single file for unfamiliar code (`cargo check`/`clippy` compile the whole
+   crate, *running* its `build.rs` and proc-macros), and invoke it with the
+   snippet's edition and `--crate-type lib` so the borrow/lifetime error isn't
+   masked by a spurious edition-or-missing-`main` one. `references/tooling.rst`
+   has the exact command and the trust-boundary note. Reserve actually executing
+   the code for when the reader asks about runtime behavior.
 3. **Idiomatic rewrite + explain the diff** — show the gap between *works* and
    *fluent*. Let `cargo clippy` find the idiom, then explain the reasoning. See
    `references/tooling.rst`.

--- a/skills/rust-explain/SKILL.md
+++ b/skills/rust-explain/SKILL.md
@@ -32,7 +32,7 @@ show what the compiler is protecting against, not just the fix.
 
 Rust evolves by **edition** (2015 → 2018 → 2021 → 2024) and the standard library
 grows every six weeks, so model knowledge drifts behind the language — the syntax
-you "remember" can be a version stale (the 2024 `unsafe extern` block is the
+you "remember" can be one version stale (the 2024 `unsafe extern` block is the
 classic trap). Correctness is the deliverable, so when a claim is high-stakes,
 confirm it against the official docs instead of asserting from memory. Fetch the
 canonical page when:
@@ -46,7 +46,9 @@ canonical page when:
 
 Routine reading needs no lookup — reach for the docs when being wrong would
 mislead. `references/canonical-sources.rst` maps each kind of question to its
-authoritative URL under `https://doc.rust-lang.org/stable/`.
+authoritative URL on the official Rust docs (mostly
+`https://doc.rust-lang.org/stable/`; a few, like the Clippy lint index, live on
+other rust-lang sites).
 
 ## Comparison policy
 
@@ -61,9 +63,11 @@ Pick the mode that fits the request:
 
 1. **Line-by-line annotate** — explain every borrow, lifetime, and `?` inline,
    in reading order.
-2. **Why does / doesn't this compile** — build borrow-checker intuition. Run the
-   code, pair it with the real `rustc` message, and explain what the rule
-   protects against. See `references/tooling.rst`.
+2. **Why does / doesn't this compile** — build borrow-checker intuition.
+   *Compile* the snippet (`cargo check` / `rustc`) to surface the real
+   diagnostic — no need to run it — then pair that message with what the rule
+   protects against. Reserve actually executing the code for when the reader
+   asks about runtime behavior. See `references/tooling.rst`.
 3. **Idiomatic rewrite + explain the diff** — show the gap between *works* and
    *fluent*. Let `cargo clippy` find the idiom, then explain the reasoning. See
    `references/tooling.rst`.
@@ -85,8 +89,9 @@ For numeric code — `ndarray`, `nalgebra`, `faer`, `polars`, `rayon`, and FFI
 into BLAS/LAPACK — load `references/numeric-idioms.rst`. It carries the
 **silent-bug radar**: where a generated kernel can be *quietly wrong* (stencil
 off-by-ones, aliasing, parallel-reduction nondeterminism) and the rule of thumb
-for what the compiler catches (memory, concurrency) versus what it cannot (your
-math).
+for what the compiler catches in **safe** code (memory, concurrency), what
+returns inside **unsafe/FFI** and must be audited by hand (the same memory and
+data-race classes), and what it *never* catches anywhere (your math).
 
 ## Tooling
 

--- a/skills/rust-explain/SKILL.md
+++ b/skills/rust-explain/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: rust-explain
+license: CC-BY-4.0
+description: >-
+  Teaching assistant for reading and navigating Rust code. Use when reading an
+  unfamiliar Rust codebase, when Rust is pasted with a question, when the borrow
+  checker or a rustc error is confusing, when a generated Rust kernel needs a
+  correctness sanity-check, or when asked to explain a specific Rust construct
+  (lifetimes, trait objects, Arc<Mutex<T>>, a macro, an iterator chain). Also
+  triggers on "explain this Rust", "what does this Rust do", "why doesn't this
+  compile", reading ownership/borrowing, FFI/unsafe blocks, or numeric crates
+  (ndarray, nalgebra, faer, polars, rayon).
+argument-hint: "Paste Rust + your question, or name a construct to explain (e.g. 'explain this lifetime', 'why doesn't this compile')"
+user-invocable: true
+metadata:
+  repo: https://github.com/nq-rdl/agent-skills
+---
+
+# Rust Explain — Read & Navigate Rust Code
+
+A teaching assistant for **reading** Rust, for a reader who already programs (a
+computational-science background) and needs to read Rust fluently and trust the
+code is correct. **Correctness is the deliverable.**
+
+## Core stance: tutor, not gatekeeper
+
+The reader forms a hypothesis; you verify it and explain the *why*. Never give
+bare approval ("looks fine") — every answer teaches. When the reader is wrong,
+show what the compiler is protecting against, not just the fix.
+
+## Comparison policy
+
+Explain Rust **on its own terms** by default. Reach for a cross-language analogy
+*only* when it genuinely clarifies, and **cap it at C++ or Python — nothing
+else.** An analogy is a bridge, not the lens. Do not compare to any other
+language.
+
+## Operating modes
+
+Pick the mode that fits the request:
+
+1. **Line-by-line annotate** — explain every borrow, lifetime, and `?` inline,
+   in reading order.
+2. **Why does / doesn't this compile** — build borrow-checker intuition. Run the
+   code, pair it with the real `rustc` message, and explain what the rule
+   protects against. See `references/tooling.rst`.
+3. **Idiomatic rewrite + explain the diff** — show the gap between *works* and
+   *fluent*. Let `cargo clippy` find the idiom, then explain the reasoning. See
+   `references/tooling.rst`.
+4. **Explain-on-demand** — explain one named construct or concept, pitched at
+   the reader's level.
+
+## The reading vocabulary
+
+Most "I can't read this" moments come from a fixed pattern set: ownership &
+borrowing, lifetimes, error flow (`Result`/`Option`/`?`), traits & generics,
+pattern matching, smart pointers (`Box`/`Rc`/`Arc`/`RefCell`/`Mutex`), closures
+& iterators, macros, modules & turbofish. Each gets a plain-English *what it
+does* + *why it's there* in `references/reading-vocabulary.rst` — load it when
+explaining any of these.
+
+## Numeric & scientific Rust
+
+For numeric code — `ndarray`, `nalgebra`, `faer`, `polars`, `rayon`, and FFI
+into BLAS/LAPACK — load `references/numeric-idioms.rst`. It carries the
+**silent-bug radar**: where a generated kernel can be *quietly wrong* (stencil
+off-by-ones, aliasing, parallel-reduction nondeterminism) and the rule of thumb
+for what the compiler catches (memory, concurrency) versus what it cannot (your
+math).
+
+## Tooling
+
+`cargo clippy`, `rustc` errors as teachers, `rust-analyzer`, `cargo doc`, and
+`cargo expand` — how to drive each and turn its output into a lesson — live in
+`references/tooling.rst`. Run them directly; this skill ships no scripts.
+
+## References
+
+- `references/reading-vocabulary.rst` — the Rust reading vocabulary
+- `references/numeric-idioms.rst` — numeric crates, FFI, silent-bug radar
+- `references/tooling.rst` — clippy, rustc, rust-analyzer, cargo doc/expand

--- a/skills/rust-explain/SKILL.md
+++ b/skills/rust-explain/SKILL.md
@@ -96,9 +96,11 @@ For numeric code — `ndarray`, `nalgebra`, `faer`, `polars`, `rayon`, and FFI
 into BLAS/LAPACK — load `references/numeric-idioms.rst`. It carries the
 **silent-bug radar**: where a generated kernel can be *quietly wrong* (stencil
 off-by-ones, aliasing, parallel-reduction nondeterminism) and the rule of thumb
-for what the compiler catches in **safe** code (memory, concurrency), what
-returns inside **unsafe/FFI** and must be audited by hand (the same memory and
-data-race classes), and what it *never* catches anywhere (your math).
+for what the compiler catches in **safe** code (memory safety and data-race
+freedom — *not* deadlocks, lock poisoning, atomic ordering, or logical races),
+what returns inside **unsafe/FFI** and must be audited by hand (the same
+memory-safety and data-race classes), and what it *never* catches anywhere (your
+math, and concurrency bugs beyond data races).
 
 ## Tooling
 

--- a/skills/rust-explain/SKILL.md
+++ b/skills/rust-explain/SKILL.md
@@ -64,10 +64,13 @@ Pick the mode that fits the request:
 1. **Line-by-line annotate** — explain every borrow, lifetime, and `?` inline,
    in reading order.
 2. **Why does / doesn't this compile** — build borrow-checker intuition.
-   *Compile* the snippet (`cargo check` / `rustc`) to surface the real
-   diagnostic — no need to run it — then pair that message with what the rule
-   protects against. Reserve actually executing the code for when the reader
-   asks about runtime behavior. See `references/tooling.rst`.
+   *Compile* the snippet to surface the real diagnostic — no need to run it —
+   then pair that message with what the rule protects against. For unfamiliar
+   code, prefer `rustc` on the single file: `cargo check`/`cargo clippy` compile
+   the whole crate, which *runs* its `build.rs` and proc-macros at check time —
+   untrusted code executes even though you never run the binary. Reserve
+   actually executing the code for when the reader asks about runtime behavior.
+   See `references/tooling.rst` (it carries the full trust-boundary note).
 3. **Idiomatic rewrite + explain the diff** — show the gap between *works* and
    *fluent*. Let `cargo clippy` find the idiom, then explain the reasoning. See
    `references/tooling.rst`.

--- a/skills/rust-explain/SKILL.md
+++ b/skills/rust-explain/SKILL.md
@@ -28,6 +28,26 @@ The reader forms a hypothesis; you verify it and explain the *why*. Never give
 bare approval ("looks fine") — every answer teaches. When the reader is wrong,
 show what the compiler is protecting against, not just the fix.
 
+## Verify against the source of truth
+
+Rust evolves by **edition** (2015 → 2018 → 2021 → 2024) and the standard library
+grows every six weeks, so model knowledge drifts behind the language — the syntax
+you "remember" can be a version stale (the 2024 `unsafe extern` block is the
+classic trap). Correctness is the deliverable, so when a claim is high-stakes,
+confirm it against the official docs instead of asserting from memory. Fetch the
+canonical page when:
+
+- the answer is **edition-sensitive** — syntax that may have changed, or code
+  that simply *looks unfamiliar*;
+- a **precise contract decides correctness** — `unsafe`/FFI invariants,
+  `as`-cast semantics, aliasing rules, the exact meaning of an `error[E####]`;
+- you are about to call something *guaranteed* or *safe* and are unsure of the
+  boundary.
+
+Routine reading needs no lookup — reach for the docs when being wrong would
+mislead. `references/canonical-sources.rst` maps each kind of question to its
+authoritative URL under `https://doc.rust-lang.org/stable/`.
+
 ## Comparison policy
 
 Explain Rust **on its own terms** by default. Reach for a cross-language analogy
@@ -54,10 +74,10 @@ Pick the mode that fits the request:
 
 Most "I can't read this" moments come from a fixed pattern set: ownership &
 borrowing, lifetimes, error flow (`Result`/`Option`/`?`), traits & generics,
-pattern matching, smart pointers (`Box`/`Rc`/`Arc`/`RefCell`/`Mutex`), closures
-& iterators, macros, modules & turbofish. Each gets a plain-English *what it
-does* + *why it's there* in `references/reading-vocabulary.rst` — load it when
-explaining any of these.
+pattern matching, smart pointers (`Box`/`Rc`/`Arc`/`Weak`/`RefCell`/`Mutex`),
+closures & iterators, macros, modules & turbofish. Each gets a plain-English
+*what it does* + *why it's there* in `references/reading-vocabulary.rst` — load
+it when explaining any of these.
 
 ## Numeric & scientific Rust
 
@@ -79,3 +99,5 @@ math).
 - `references/reading-vocabulary.rst` — the Rust reading vocabulary
 - `references/numeric-idioms.rst` — numeric crates, FFI, silent-bug radar
 - `references/tooling.rst` — clippy, rustc, rust-analyzer, cargo doc/expand
+- `references/canonical-sources.rst` — official Rust docs to fetch when a
+  high-stakes claim needs verifying (the source of truth)

--- a/skills/rust-explain/SKILL.md
+++ b/skills/rust-explain/SKILL.md
@@ -65,13 +65,16 @@ Pick the mode that fits the request:
    in reading order.
 2. **Why does / doesn't this compile** — build borrow-checker intuition.
    *Compile* the snippet to surface the real diagnostic — no need to run it —
-   then pair that message with what the rule protects against. Prefer `rustc` on
-   the single file for unfamiliar code (`cargo check`/`clippy` compile the whole
-   crate, *running* its `build.rs` and proc-macros), and invoke it with the
-   snippet's edition and `--crate-type lib` so the borrow/lifetime error isn't
-   masked by a spurious edition-or-missing-`main` one. `references/tooling.rst`
-   has the exact command and the trust-boundary note. Reserve actually executing
-   the code for when the reader asks about runtime behavior.
+   then pair that message with what the rule protects against. Invoke `rustc`
+   with the snippet's edition and `--crate-type lib` so the borrow/lifetime
+   error isn't masked by a spurious edition-or-missing-`main` one. **Mind the
+   trust boundary:** compiling runs code (Cargo runs `build.rs`/proc-macros), and
+   even `rustc` type-checking expands built-in macros like `env!`/`include_str!`
+   that can leak local data into the diagnostics you read back — so compile
+   *untrusted* code only in a scrubbed sandbox, or just read it statically.
+   `references/tooling.rst` has the exact command and the full trust-boundary
+   note. Reserve actually executing the code for when the reader asks about
+   runtime behavior.
 3. **Idiomatic rewrite + explain the diff** — show the gap between *works* and
    *fluent*. Let `cargo clippy` find the idiom, then explain the reasoning. See
    `references/tooling.rst`.

--- a/skills/rust-explain/references/canonical-sources.rst
+++ b/skills/rust-explain/references/canonical-sources.rst
@@ -22,9 +22,17 @@ cast / aliasing contract, the exact meaning of an ``error[E####]``, or a
 "guaranteed / safe" claim near the boundary of what the compiler promises. This
 file is the *where*.
 
-Use the ``stable`` channel (latest release) by default. If the code targets a
-specific edition, the **Edition Guide** is what reconciles "this compiles for
-them but looks wrong to me."
+Use the ``stable`` channel (latest release) by default — **but first check
+whether the project pins a version.** Editions are not the whole story: a crate
+can declare a minimum supported Rust version (``rust-version`` in
+``Cargo.toml``), repos often pin an exact toolchain (``rust-toolchain.toml``, or
+in CI), and the standard library grows new APIs and lints every six weeks.
+Before asserting an API exists or that an idiom compiles, read those pins and
+consult the docs for *that* version (or the project's own ``cargo doc`` against
+its toolchain) — latest-stable docs can show ``std`` APIs the project's compiler
+does not have, so an edition check alone will not catch the skew. If the code
+targets a specific edition, the **Edition Guide** is what reconciles "this
+compiles for them but looks wrong to me."
 
 The core documentation set
 --------------------------
@@ -79,7 +87,9 @@ references:
 - Aliasing and ``unsafe`` contracts — `Reference: Behavior considered undefined
   <https://doc.rust-lang.org/stable/reference/behavior-considered-undefined.html>`__
   is the authoritative list (e.g. two live ``&mut`` to overlapping memory is UB;
-  raw pointers are exempt). Conceptual intro: `Nomicon: Aliasing
+  a raw pointer carries no aliasing requirement *of its own*, but an *access*
+  through it — or an FFI write — that conflicts with a live ``&``/``&mut`` is
+  still UB). Conceptual intro: `Nomicon: Aliasing
   <https://doc.rust-lang.org/stable/nomicon/aliasing.html>`__; FFI specifics:
   `Nomicon: FFI <https://doc.rust-lang.org/stable/nomicon/ffi.html>`__.
 - Slice splitting / unchecked access contracts — `std::slice
@@ -90,3 +100,12 @@ references:
   moved value), `E0502
   <https://doc.rust-lang.org/stable/error_codes/E0502.html>`__ (mutable +
   immutable borrow).
+- Minimum supported Rust version / toolchain pinning — `Cargo: the rust-version
+  field <https://doc.rust-lang.org/stable/cargo/reference/rust-version.html>`__
+  (a project's supported compiler; check this and any ``rust-toolchain.toml``
+  before asserting an API exists or an idiom compiles, since ``std`` grows
+  faster than editions change).
+- rust-analyzer trust boundary — `rust-analyzer: Security
+  <https://rust-analyzer.github.io/book/security.html>`__ (it runs build scripts
+  and proc-macros by default, so opening an untrusted workspace can execute
+  code; the page lists the settings that disable that).

--- a/skills/rust-explain/references/canonical-sources.rst
+++ b/skills/rust-explain/references/canonical-sources.rst
@@ -16,16 +16,11 @@ expressions") so this file stays the one place a link is maintained.
 When to reach for these
 -----------------------
 
-Routine reading needs no lookup. Fetch when being wrong would mislead:
-
-- **Edition-sensitive syntax** — anything that may have changed across editions,
-  or code that simply *looks unfamiliar* (``unsafe extern``, ``gen`` blocks,
-  ``let``-chains, ``async fn`` in traits). Start at the Edition Guide.
-- **A precise contract that decides correctness** — ``unsafe`` / FFI invariants,
-  ``as``-cast semantics, aliasing rules, the exact guarantee of a ``std`` method
-  (read its *Safety* section), the full meaning of an ``error[E####]``.
-- **A "guaranteed" / "safe" claim** you are about to make near the boundary of
-  what the compiler actually promises.
+``SKILL.md`` ("Verify against the source of truth") is the single statement of
+*when* to fetch — in short: edition-sensitive syntax, a precise ``unsafe`` /
+cast / aliasing contract, the exact meaning of an ``error[E####]``, or a
+"guaranteed / safe" claim near the boundary of what the compiler promises. This
+file is the *where*.
 
 Use the ``stable`` channel (latest release) by default. If the code targets a
 specific edition, the **Edition Guide** is what reconciles "this compiles for
@@ -80,14 +75,17 @@ references:
   `std::rc::Weak <https://doc.rust-lang.org/stable/std/rc/struct.Weak.html>`__ /
   `std::sync::Weak
   <https://doc.rust-lang.org/stable/std/sync/struct.Weak.html>`__.
-- Aliasing and ``unsafe`` contracts — `Nomicon: Aliasing
-  <https://doc.rust-lang.org/stable/nomicon/aliasing.html>`__ and `Nomicon: FFI
-  <https://doc.rust-lang.org/stable/nomicon/ffi.html>`__.
+- Aliasing and ``unsafe`` contracts — `Reference: Behavior considered undefined
+  <https://doc.rust-lang.org/stable/reference/behavior-considered-undefined.html>`__
+  is the authoritative list (e.g. two live ``&mut`` to overlapping memory is UB;
+  raw pointers are exempt). Conceptual intro: `Nomicon: Aliasing
+  <https://doc.rust-lang.org/stable/nomicon/aliasing.html>`__; FFI specifics:
+  `Nomicon: FFI <https://doc.rust-lang.org/stable/nomicon/ffi.html>`__.
 - Slice splitting / unchecked access contracts — `std::slice
   <https://doc.rust-lang.org/stable/std/primitive.slice.html>`__ (read the
   *Safety* note on ``get_unchecked`` and the guarantee on ``split_at_mut``).
 - Borrow / move diagnostics — `error_codes: E0382
-  <https://doc.rust-lang.org/stable/error_codes/E0382.html>`__ (borrow of moved
-  value), `E0502
+  <https://doc.rust-lang.org/stable/error_codes/E0382.html>`__ (use/borrow of a
+  moved value), `E0502
   <https://doc.rust-lang.org/stable/error_codes/E0502.html>`__ (mutable +
   immutable borrow).

--- a/skills/rust-explain/references/canonical-sources.rst
+++ b/skills/rust-explain/references/canonical-sources.rst
@@ -1,0 +1,93 @@
+Canonical Rust Documentation — Where to Verify
+==============================================
+
+The source of truth for everything this skill explains. Rust evolves by
+**edition** (2015 → 2018 → 2021 → 2024) and the standard library grows every
+six weeks, so a remembered fact can be a version stale — the bare
+``extern "C"`` block, a cast rule, a lint name. When the reader's correctness
+depends on a detail you are not certain of, **fetch the page below and read the
+current wording** instead of asserting from memory. That is the difference
+between teaching Rust and teaching last year's Rust.
+
+This is the master list: keep full URLs here, and cite docs *by name and
+section* at the point of use elsewhere (e.g. "Reference → Type cast
+expressions") so this file stays the one place a link is maintained.
+
+When to reach for these
+-----------------------
+
+Routine reading needs no lookup. Fetch when being wrong would mislead:
+
+- **Edition-sensitive syntax** — anything that may have changed across editions,
+  or code that simply *looks unfamiliar* (``unsafe extern``, ``gen`` blocks,
+  ``let``-chains, ``async fn`` in traits). Start at the Edition Guide.
+- **A precise contract that decides correctness** — ``unsafe`` / FFI invariants,
+  ``as``-cast semantics, aliasing rules, the exact guarantee of a ``std`` method
+  (read its *Safety* section), the full meaning of an ``error[E####]``.
+- **A "guaranteed" / "safe" claim** you are about to make near the boundary of
+  what the compiler actually promises.
+
+Use the ``stable`` channel (latest release) by default. If the code targets a
+specific edition, the **Edition Guide** is what reconciles "this compiles for
+them but looks wrong to me."
+
+The core documentation set
+--------------------------
+
+- **The Rust Programming Language** ("the Book") —
+  https://doc.rust-lang.org/stable/book/ — concept-first learning: ownership,
+  borrowing, lifetimes, traits, smart pointers. Best for building a reader's
+  intuition.
+- **The Rust Reference** — https://doc.rust-lang.org/stable/reference/ — the
+  authoritative description of syntax and semantics. The source of truth for
+  "what *exactly* does this do" (cast rules, operator behavior, item forms).
+- **Standard library API** — https://doc.rust-lang.org/stable/std/ — every
+  ``std`` type and method, each ``unsafe`` method carrying a **Safety** section
+  that states its contract. Use the search box at the top.
+- **The Rustonomicon** — https://doc.rust-lang.org/stable/nomicon/ — the
+  authority on ``unsafe`` Rust: raw pointers, aliasing, FFI, and the invariants
+  an ``unsafe`` block must uphold. Reach here to audit ``unsafe`` / FFI.
+- **The Edition Guide** — https://doc.rust-lang.org/stable/edition-guide/ — what
+  changed between editions. First stop when syntax looks new or "wrong."
+- **Error code index** — https://doc.rust-lang.org/stable/error_codes/ — the
+  long-form explanation behind every ``error[E####]`` (the same text
+  ``rustc --explain E0382`` prints).
+- **Rust by Example** — https://doc.rust-lang.org/stable/rust-by-example/ —
+  short, runnable, annotated examples.
+- **The Cargo Book** — https://doc.rust-lang.org/stable/cargo/ — ``cargo``
+  commands and the manifest format.
+- **Clippy lint index** — https://rust-lang.github.io/rust-clippy/stable/ —
+  what each Clippy lint means and *why* it fires (official, but hosted on
+  ``rust-lang.github.io`` rather than ``doc.rust-lang.org``). Prefer the
+  ``/stable/`` index over ``/master/``.
+
+Pinpoint links for what this skill teaches
+------------------------------------------
+
+The deep links behind the trickier, drift-prone passages in the other
+references:
+
+- ``as`` cast semantics (int→int truncates/wraps, float→int saturates, ``NaN`` →
+  0) — `Reference: Type cast expressions
+  <https://doc.rust-lang.org/stable/reference/expressions/operator-expr.html#type-cast-expressions>`__.
+- 2024-edition ``unsafe extern`` blocks (and per-item ``safe`` / ``unsafe``) —
+  `Edition Guide: Unsafe extern blocks
+  <https://doc.rust-lang.org/stable/edition-guide/rust-2024/unsafe-extern.html>`__,
+  with the full grammar in `Reference: External blocks
+  <https://doc.rust-lang.org/stable/reference/items/external-blocks.html>`__.
+- Reference cycles and ``Weak<T>`` — `Book §15.6: Reference Cycles Can Leak
+  Memory <https://doc.rust-lang.org/stable/book/ch15-06-reference-cycles.html>`__;
+  `std::rc::Weak <https://doc.rust-lang.org/stable/std/rc/struct.Weak.html>`__ /
+  `std::sync::Weak
+  <https://doc.rust-lang.org/stable/std/sync/struct.Weak.html>`__.
+- Aliasing and ``unsafe`` contracts — `Nomicon: Aliasing
+  <https://doc.rust-lang.org/stable/nomicon/aliasing.html>`__ and `Nomicon: FFI
+  <https://doc.rust-lang.org/stable/nomicon/ffi.html>`__.
+- Slice splitting / unchecked access contracts — `std::slice
+  <https://doc.rust-lang.org/stable/std/primitive.slice.html>`__ (read the
+  *Safety* note on ``get_unchecked`` and the guarantee on ``split_at_mut``).
+- Borrow / move diagnostics — `error_codes: E0382
+  <https://doc.rust-lang.org/stable/error_codes/E0382.html>`__ (borrow of moved
+  value), `E0502
+  <https://doc.rust-lang.org/stable/error_codes/E0502.html>`__ (mutable +
+  immutable borrow).

--- a/skills/rust-explain/references/canonical-sources.rst
+++ b/skills/rust-explain/references/canonical-sources.rst
@@ -3,7 +3,7 @@ Canonical Rust Documentation — Where to Verify
 
 The source of truth for everything this skill explains. Rust evolves by
 **edition** (2015 → 2018 → 2021 → 2024) and the standard library grows every
-six weeks, so a remembered fact can be a version stale — the bare
+six weeks, so a remembered fact can be one version stale — the bare
 ``extern "C"`` block, a cast rule, a lint name. When the reader's correctness
 depends on a detail you are not certain of, **fetch the page below and read the
 current wording** instead of asserting from memory. That is the difference
@@ -62,8 +62,9 @@ Pinpoint links for what this skill teaches
 The deep links behind the trickier, drift-prone passages in the other
 references:
 
-- ``as`` cast semantics (int→int truncates/wraps, float→int saturates, ``NaN`` →
-  0) — `Reference: Type cast expressions
+- ``as`` cast semantics (int→int: narrowing truncates, widening
+  sign/zero-extends, same-width reinterprets; float→int saturates, ``NaN`` → 0)
+  — `Reference: Type cast expressions
   <https://doc.rust-lang.org/stable/reference/expressions/operator-expr.html#type-cast-expressions>`__.
 - 2024-edition ``unsafe extern`` blocks (and per-item ``safe`` / ``unsafe``) —
   `Edition Guide: Unsafe extern blocks

--- a/skills/rust-explain/references/numeric-idioms.rst
+++ b/skills/rust-explain/references/numeric-idioms.rst
@@ -24,12 +24,14 @@ Ecosystem Idioms to Recognize
 FFI Reading: Rust Calling Native Libraries
 ------------------------------------------
 
-A call into a C-ABI library (BLAS / LAPACK, a vendor kernel) looks like this:
+A call into a C-ABI library (BLAS / LAPACK, a vendor kernel) looks like this on
+the **2024 edition**:
 
 .. code:: rust
 
-   extern "C" {
-       // declares a function provided by a C library, linked at build time
+   unsafe extern "C" {               // 2024 edition: the extern block is `unsafe`
+       // a function provided by a C library, linked at build time;
+       // an unmarked item defaults to `unsafe` to call
        fn cblas_ddot(n: i32, x: *const f64, incx: i32, y: *const f64, incy: i32) -> f64;
    }
 
@@ -40,6 +42,13 @@ A call into a C-ABI library (BLAS / LAPACK, a vendor kernel) looks like this:
 Reading rules:
 
 - ``extern "C"`` = "this uses the C ABI" (the calling convention for FFI).
+- **Editions differ — expect both forms.** Since the 2024 edition the block
+  must be written ``unsafe extern "C" { … }``, and each item may be marked
+  ``safe`` (callable without an ``unsafe`` block) or ``unsafe`` / left unmarked
+  (the caller upholds the contract). Crates on the 2015/2018/2021 editions still
+  use a bare ``extern "C" { … }``. If the form looks unfamiliar, confirm against
+  the Edition Guide (``references/canonical-sources.rst``) rather than guessing
+  — this is exactly the kind of syntax that drifts between editions.
 - Raw pointers ``*const T`` / ``*mut T`` are the C-facing types; ``.as_ptr()``
   hands a slice's buffer to C.
 - ``unsafe`` does **not** mean "wrong." It means *the compiler's guarantees stop
@@ -49,14 +58,20 @@ Reading rules:
 Silent-Bug Radar (highest value)
 --------------------------------
 
-Rust's compiler eliminates whole bug classes — but only some. Anchor every review
-on this split.
+Rust's compiler eliminates whole bug classes — but **only in safe code, and
+never your math.** Anchor every review on this split.
 
-**The compiler catches** (do not re-audit these): use-after-free, double-free,
-data races on shared memory, out-of-bounds via a runtime panic, null
-dereferences, uninitialized reads.
+**In safe Rust the compiler catches** (do not re-audit these in safe code):
+use-after-free, double-free, data races on shared memory, out-of-bounds (a
+runtime panic, not silent corruption), null dereferences, uninitialized reads.
 
-**The compiler cannot catch** (audit these every time): *your math.* Code that
+**Inside ``unsafe`` / FFI they come back.** A wrong pointer, length, or lifetime
+in an ``unsafe`` block or a C call can reintroduce every one of those — the
+``unsafe`` contract, not the compiler, is what holds them off. Audit each
+``unsafe`` region for exactly the bugs safe Rust had ruled out (Nomicon, via
+``references/canonical-sources.rst``).
+
+**The compiler never catches** (audit these every time): *your math.* Code that
 satisfies the borrow checker can still compute the wrong number.
 
 Look hard at:
@@ -65,16 +80,30 @@ Look hard at:
   ``1..n``, halo / ghost-cell handling, ``len()`` versus ``len()-1``. A bounds
   check turns a bad index into a *panic*, not a silently wrong result — but the
   wrong-but-in-range index is silent.
-- **Aliasing assumptions in ``unsafe`` / FFI.** Code using ``get_unchecked``,
-  ``split_at_mut``, or raw pointers promises "these do not overlap." If they can
-  overlap, results are silently corrupt.
+- **Aliasing & bounds promises in ``unsafe`` / FFI.** Read the contract
+  precisely — the common constructs promise *different* things. ``split_at_mut``
+  is **safe**: it hands back two slices the compiler *guarantees* do not
+  overlap, so trust it. ``get_unchecked`` / ``get_unchecked_mut`` are
+  **unsafe** and promise only *the index is in bounds* (a wrong index is
+  undefined behavior, not a panic). The **aliasing** rule binds *references*,
+  not raw pointers: a ``*mut T`` may alias freely, but the instant unsafe code
+  turns raw pointers or unchecked access into two live ``&mut`` over overlapping
+  memory, that is undefined behavior. Audit where unsafe code *materializes*
+  those references, not the safe ``split_at_mut`` helper; a broken aliasing
+  assumption corrupts results silently (std ``slice`` docs; Nomicon → Aliasing).
 - **Parallel-reduction nondeterminism.** Floating-point ``+`` is not associative,
   so a ``rayon`` reduction can give a *different sum* per run depending on
   chunking — correct-looking, not reproducible. Flag when a ``par_iter().sum()``
   or a custom ``reduce`` feeds a result that must be bit-reproducible.
-- **Integer / float casts.** ``as`` truncates or saturates silently
-  (``300_i32 as u8`` is ``44``); ``usize`` index arithmetic can wrap.
+- **Integer / float casts.** ``as`` is silent and the rule depends on the
+  types: integer→integer **truncates / wraps** (``300_i32 as u8`` is ``44``),
+  while float→integer **saturates** to the target's range with ``NaN`` mapping
+  to ``0`` (``300.0_f32 as u8`` is ``255``, ``-1.0_f32 as u8`` is ``0``).
+  Separately, overflowing *arithmetic* on ``usize`` indices **panics in debug
+  builds but wraps in release** — so an index bug can stay hidden until the
+  optimized build (Reference → Type cast expressions).
 
-When reviewing a generated kernel, state the split explicitly: "the compiler
-guarantees memory and thread safety here; it does **not** guarantee the
-arithmetic — check the indices, the reduction order, and the casts."
+When reviewing a generated kernel, state the split explicitly: "in the safe
+regions the compiler guarantees memory and thread safety; inside ``unsafe`` /
+FFI you must audit those too; **nowhere** does it guarantee the arithmetic —
+check the indices, the reduction order, and the casts."

--- a/skills/rust-explain/references/numeric-idioms.rst
+++ b/skills/rust-explain/references/numeric-idioms.rst
@@ -61,10 +61,14 @@ Silent-Bug Radar (highest value)
 Rust's compiler eliminates whole bug classes — but **only in safe code, and
 never your math.** Anchor every review on this split.
 
-**In safe Rust the compiler catches** (no longer *memory-safety* bugs to
-re-audit there): use-after-free, double-free, data races on shared memory,
-out-of-bounds (still a runtime panic to handle, just never silent corruption),
-null dereferences, uninitialized reads.
+**In safe Rust, memory safety is not yours to re-audit** — but mind *how* each
+class is ruled out. The compiler **rejects at compile time**: use-after-free,
+double-free, data races on shared memory, null dereferences, uninitialized
+reads. **Out-of-bounds is different** — the compiler does *not* catch it; safe
+Rust instead **converts it into a guaranteed runtime panic** (or a ``None`` from
+``.get()``), never silent corruption. So indexing is safe from *corruption*, but
+a wrong index still panics — a production failure to handle, and a correctness
+bug to chase (the stencil off-by-ones below).
 
 **Inside ``unsafe`` / FFI they come back.** A wrong pointer, length, or lifetime
 in an ``unsafe`` block or a C call can reintroduce every one of those — the

--- a/skills/rust-explain/references/numeric-idioms.rst
+++ b/skills/rust-explain/references/numeric-idioms.rst
@@ -11,8 +11,15 @@ Ecosystem Idioms to Recognize
 - **ndarray** — N-dimensional arrays (the NumPy of Rust). ``Array2<f64>`` is an
   owned 2-D array; ``ArrayView2<f64>`` borrows one. Watch for ``.slice()`` with
   the ``s![..]`` indexing macro.
-- **nalgebra** — linear algebra with *compile-time* dimensions: ``Matrix3<f64>``,
-  ``Vector4<f64>``. Dimension mismatches become type errors.
+- **nalgebra** — linear algebra where *statically sized* types carry their
+  dimensions in the type: ``Matrix3<f64>``, ``Vector4<f64>``, ``SMatrix`` — there
+  a shape mismatch is a *compile-time* type error. But nalgebra also has
+  **dynamically sized** ``DMatrix<f64>`` / ``DVector<f64>`` (and mixed
+  static/dynamic shapes) whose dimensions are known only at runtime: there a
+  mismatch is a **runtime panic**, not a type error. Don't read "nalgebra" as
+  "shapes proven at compile time" — check whether the types are static or
+  dynamic, and guard or test dynamic operations the way you would any runtime
+  bound.
 - **faer** — high-performance dense linear algebra (decompositions, solves) built
   for speed; recognize ``faer::Mat``.
 - **polars** — dataframes (the Rust pandas): a lazy ``LazyFrame`` query plan and

--- a/skills/rust-explain/references/numeric-idioms.rst
+++ b/skills/rust-explain/references/numeric-idioms.rst
@@ -84,23 +84,26 @@ Look hard at:
   precisely — the common constructs promise *different* things. ``split_at_mut``
   is **safe**: it hands back two slices the compiler *guarantees* do not
   overlap, so trust it. ``get_unchecked`` / ``get_unchecked_mut`` are
-  **unsafe** and promise only *the index is in bounds* (a wrong index is
-  undefined behavior, not a panic). The **aliasing** rule binds *references*,
-  not raw pointers: a ``*mut T`` may alias freely, but the instant unsafe code
-  turns raw pointers or unchecked access into two live ``&mut`` over overlapping
-  memory, that is undefined behavior. Audit where unsafe code *materializes*
-  those references, not the safe ``split_at_mut`` helper; a broken aliasing
-  assumption corrupts results silently (std ``slice`` docs; Nomicon → Aliasing).
+  **unsafe**: they drop the bounds check, so the *caller* must guarantee the
+  index is in bounds (a wrong index is undefined behavior, not a panic). The
+  **aliasing** rule binds *references*, not raw pointers — a ``*mut T`` carries
+  no aliasing requirement of its own — but the instant unsafe code turns raw
+  pointers or unchecked access into two live ``&mut`` over overlapping memory,
+  that is undefined behavior. Audit where unsafe code *materializes* those
+  references, not the safe ``split_at_mut`` helper; a broken aliasing assumption
+  corrupts results silently (Reference → Behavior considered undefined; std
+  ``slice`` docs).
 - **Parallel-reduction nondeterminism.** Floating-point ``+`` is not associative,
   so a ``rayon`` reduction can give a *different sum* per run depending on
   chunking — correct-looking, not reproducible. Flag when a ``par_iter().sum()``
   or a custom ``reduce`` feeds a result that must be bit-reproducible.
 - **Integer / float casts.** ``as`` is silent and the rule depends on the
-  types: integer→integer **truncates / wraps** (``300_i32 as u8`` is ``44``),
-  while float→integer **saturates** to the target's range with ``NaN`` mapping
-  to ``0`` (``300.0_f32 as u8`` is ``255``, ``-1.0_f32 as u8`` is ``0``).
-  Separately, overflowing *arithmetic* on ``usize`` indices **panics in debug
-  builds but wraps in release** — so an index bug can stay hidden until the
+  types: integer→integer **truncates to the low bits** (``300_i32 as u8`` is
+  ``44``), while float→integer **saturates** to the target's range with ``NaN``
+  mapping to ``0`` (``300.0_f32 as u8`` is ``255``, ``-1.0_f32 as u8`` is
+  ``0``). Separately, overflowing *arithmetic* on ``usize`` indices **panics in
+  debug builds but wraps in release by default** (it tracks the
+  ``overflow-checks`` profile flag) — so an index bug can stay hidden until the
   optimized build (Reference → Type cast expressions).
 
 When reviewing a generated kernel, state the split explicitly: "in the safe

--- a/skills/rust-explain/references/numeric-idioms.rst
+++ b/skills/rust-explain/references/numeric-idioms.rst
@@ -61,9 +61,10 @@ Silent-Bug Radar (highest value)
 Rust's compiler eliminates whole bug classes — but **only in safe code, and
 never your math.** Anchor every review on this split.
 
-**In safe Rust the compiler catches** (do not re-audit these in safe code):
-use-after-free, double-free, data races on shared memory, out-of-bounds (a
-runtime panic, not silent corruption), null dereferences, uninitialized reads.
+**In safe Rust the compiler catches** (no longer *memory-safety* bugs to
+re-audit there): use-after-free, double-free, data races on shared memory,
+out-of-bounds (still a runtime panic to handle, just never silent corruption),
+null dereferences, uninitialized reads.
 
 **Inside ``unsafe`` / FFI they come back.** A wrong pointer, length, or lifetime
 in an ``unsafe`` block or a C call can reintroduce every one of those — the
@@ -98,13 +99,19 @@ Look hard at:
   chunking — correct-looking, not reproducible. Flag when a ``par_iter().sum()``
   or a custom ``reduce`` feeds a result that must be bit-reproducible.
 - **Integer / float casts.** ``as`` is silent and the rule depends on the
-  types: integer→integer **truncates to the low bits** (``300_i32 as u8`` is
-  ``44``), while float→integer **saturates** to the target's range with ``NaN``
-  mapping to ``0`` (``300.0_f32 as u8`` is ``255``, ``-1.0_f32 as u8`` is
-  ``0``). Separately, overflowing *arithmetic* on ``usize`` indices **panics in
-  debug builds but wraps in release by default** (it tracks the
-  ``overflow-checks`` profile flag) — so an index bug can stay hidden until the
-  optimized build (Reference → Type cast expressions).
+  types. A **narrowing** integer→integer cast keeps the low bits
+  (``300_i32 as u8`` is ``44``). A **widening** cast that stays in the same
+  signedness preserves the value (``-1_i8 as i32`` is ``-1``; ``200_u8 as u32``
+  is ``200``). But casting a **signed value into an unsigned type** turns a
+  negative number into a large positive one — ``-1_i32 as u32`` is
+  ``4294967295`` and ``-1_i32 as usize`` is ``usize::MAX`` — the classic silent
+  ``-1``-as-index bug, regardless of width. Meanwhile float→integer
+  **saturates** to the target's range with ``NaN`` mapping to ``0``
+  (``300.0_f32 as u8`` is ``255``, ``-1.0_f32 as u8`` is ``0``). Separately,
+  overflowing *arithmetic* on ``usize`` indices **panics in debug builds but
+  wraps in release by default**
+  (it tracks the ``overflow-checks`` profile flag) — so an index bug can stay
+  hidden until the optimized build (Reference → Type cast expressions).
 
 When reviewing a generated kernel, state the split explicitly: "in the safe
 regions the compiler guarantees memory and thread safety; inside ``unsafe`` /

--- a/skills/rust-explain/references/numeric-idioms.rst
+++ b/skills/rust-explain/references/numeric-idioms.rst
@@ -1,0 +1,80 @@
+Numeric & Scientific Rust
+=========================
+
+A recognition guide for numeric Rust, plus the highest-value job: catching code
+that compiles but is **quietly wrong**. The reader has a computational-science
+background — correctness is the deliverable.
+
+Ecosystem Idioms to Recognize
+-----------------------------
+
+- **ndarray** — N-dimensional arrays (the NumPy of Rust). ``Array2<f64>`` is an
+  owned 2-D array; ``ArrayView2<f64>`` borrows one. Watch for ``.slice()`` with
+  the ``s![..]`` indexing macro.
+- **nalgebra** — linear algebra with *compile-time* dimensions: ``Matrix3<f64>``,
+  ``Vector4<f64>``. Dimension mismatches become type errors.
+- **faer** — high-performance dense linear algebra (decompositions, solves) built
+  for speed; recognize ``faer::Mat``.
+- **polars** — dataframes (the Rust pandas): a lazy ``LazyFrame`` query plan and
+  an eager ``DataFrame``.
+- **rayon** — data parallelism by changing ``.iter()`` to ``.par_iter()``. If you
+  see ``par_iter`` / ``par_bridge`` / ``into_par_iter``, the loop runs on a
+  thread pool.
+
+FFI Reading: Rust Calling Native Libraries
+------------------------------------------
+
+A call into a C-ABI library (BLAS / LAPACK, a vendor kernel) looks like this:
+
+.. code:: rust
+
+   extern "C" {
+       // declares a function provided by a C library, linked at build time
+       fn cblas_ddot(n: i32, x: *const f64, incx: i32, y: *const f64, incy: i32) -> f64;
+   }
+
+   let dot = unsafe {                 // unsafe: the compiler cannot verify the C side
+       cblas_ddot(n, x.as_ptr(), 1, y.as_ptr(), 1)
+   };
+
+Reading rules:
+
+- ``extern "C"`` = "this uses the C ABI" (the calling convention for FFI).
+- Raw pointers ``*const T`` / ``*mut T`` are the C-facing types; ``.as_ptr()``
+  hands a slice's buffer to C.
+- ``unsafe`` does **not** mean "wrong." It means *the compiler's guarantees stop
+  here; a human asserts the contract*. Read every ``unsafe`` block as a claim to
+  audit: are the pointers valid, the lengths right, the data still live?
+
+Silent-Bug Radar (highest value)
+--------------------------------
+
+Rust's compiler eliminates whole bug classes — but only some. Anchor every review
+on this split.
+
+**The compiler catches** (do not re-audit these): use-after-free, double-free,
+data races on shared memory, out-of-bounds via a runtime panic, null
+dereferences, uninitialized reads.
+
+**The compiler cannot catch** (audit these every time): *your math.* Code that
+satisfies the borrow checker can still compute the wrong number.
+
+Look hard at:
+
+- **Stencil / index off-by-ones.** Loop bounds such as ``1..n-1`` versus
+  ``1..n``, halo / ghost-cell handling, ``len()`` versus ``len()-1``. A bounds
+  check turns a bad index into a *panic*, not a silently wrong result — but the
+  wrong-but-in-range index is silent.
+- **Aliasing assumptions in ``unsafe`` / FFI.** Code using ``get_unchecked``,
+  ``split_at_mut``, or raw pointers promises "these do not overlap." If they can
+  overlap, results are silently corrupt.
+- **Parallel-reduction nondeterminism.** Floating-point ``+`` is not associative,
+  so a ``rayon`` reduction can give a *different sum* per run depending on
+  chunking — correct-looking, not reproducible. Flag when a ``par_iter().sum()``
+  or a custom ``reduce`` feeds a result that must be bit-reproducible.
+- **Integer / float casts.** ``as`` truncates or saturates silently
+  (``300_i32 as u8`` is ``44``); ``usize`` index arithmetic can wrap.
+
+When reviewing a generated kernel, state the split explicitly: "the compiler
+guarantees memory and thread safety here; it does **not** guarantee the
+arithmetic — check the indices, the reduction order, and the casts."

--- a/skills/rust-explain/references/numeric-idioms.rst
+++ b/skills/rust-explain/references/numeric-idioms.rst
@@ -113,6 +113,14 @@ Look hard at:
   so a ``rayon`` reduction can give a *different sum* per run depending on
   chunking — correct-looking, not reproducible. Flag when a ``par_iter().sum()``
   or a custom ``reduce`` feeds a result that must be bit-reproducible.
+- **Concurrency beyond data races.** Safe Rust rules out *data races*, not
+  concurrency bugs in general — ``Arc<Mutex<T>>`` and ``rayon`` code that
+  compiles can still **deadlock**, **poison a lock** (``.lock()`` returns
+  ``Err`` after a holder panics mid-critical-section), use the wrong atomic
+  ``Ordering`` (``Relaxed`` where ``Acquire``/``Release`` was needed), or lose a
+  **check-then-act race** across two locks or atomics. The symptom is a hang or
+  a nondeterministic wrong result, never a compile error — so audit the *logic*,
+  not just the types.
 - **Integer / float casts.** ``as`` is silent and the rule depends on the
   types. A **narrowing** integer→integer cast keeps the low bits
   (``300_i32 as u8`` is ``44``). A **widening** cast that stays in the same
@@ -129,6 +137,8 @@ Look hard at:
   hidden until the optimized build (Reference → Type cast expressions).
 
 When reviewing a generated kernel, state the split explicitly: "in the safe
-regions the compiler guarantees memory and thread safety; inside ``unsafe`` /
-FFI you must audit those too; **nowhere** does it guarantee the arithmetic —
-check the indices, the reduction order, and the casts."
+regions the compiler guarantees memory safety and data-race freedom (not
+deadlocks, lock poisoning, atomic ordering, or logical races); inside
+``unsafe`` / FFI you must audit those memory and data-race classes too;
+**nowhere** does it guarantee the arithmetic or the concurrency logic — check
+the indices, the reduction order, the casts, and the locking."

--- a/skills/rust-explain/references/numeric-idioms.rst
+++ b/skills/rust-explain/references/numeric-idioms.rst
@@ -91,13 +91,17 @@ Look hard at:
   overlap, so trust it. ``get_unchecked`` / ``get_unchecked_mut`` are
   **unsafe**: they drop the bounds check, so the *caller* must guarantee the
   index is in bounds (a wrong index is undefined behavior, not a panic). The
-  **aliasing** rule binds *references*, not raw pointers — a ``*mut T`` carries
-  no aliasing requirement of its own — but the instant unsafe code turns raw
-  pointers or unchecked access into two live ``&mut`` over overlapping memory,
-  that is undefined behavior. Audit where unsafe code *materializes* those
-  references, not the safe ``split_at_mut`` helper; a broken aliasing assumption
-  corrupts results silently (Reference → Behavior considered undefined; std
-  ``slice`` docs).
+  **aliasing** rule constrains *live references*, and it bites on every *access*
+  to that memory while a reference is live — not only when a second reference is
+  created. Holding several ``*mut T`` is fine in itself, but *reading or writing*
+  through a raw pointer (or letting C/FFI write) while a ``&mut`` to the same
+  bytes is live — or mutating while a non-``UnsafeCell`` ``&`` is live — is
+  undefined behavior, even though no second ``&mut`` ever exists. So audit the
+  *accesses*: every raw-pointer load/store and FFI write that touches memory a
+  live reference still covers, not just where unsafe code hands out another
+  reference (and ``split_at_mut`` itself stays safe — its two slices are
+  disjoint by construction). A broken aliasing assumption corrupts results
+  silently (Reference → Behavior considered undefined; std ``slice`` docs).
 - **Parallel-reduction nondeterminism.** Floating-point ``+`` is not associative,
   so a ``rayon`` reduction can give a *different sum* per run depending on
   chunking — correct-looking, not reproducible. Flag when a ``par_iter().sum()``

--- a/skills/rust-explain/references/reading-vocabulary.rst
+++ b/skills/rust-explain/references/reading-vocabulary.rst
@@ -1,0 +1,179 @@
+Rust Reading Vocabulary
+=======================
+
+The fixed pattern set behind most "I can't read this." For a reader who already
+programs: each entry is **what it does** + **why it's there**, oriented toward
+*reading* code, not writing it. Explain on Rust's own terms; reach for a C++ or
+Python analogy only when it truly clarifies.
+
+Ownership & Borrowing
+---------------------
+
+``T`` owns its value; ``&T`` borrows it (shared, read-only); ``&mut T`` borrows
+it exclusively (read-write). Assigning or passing an owned non-``Copy`` value
+*moves* it — the source can no longer be used.
+
+.. code:: rust
+
+   let s = String::from("grid");
+   let t = s;            // value MOVES from s to t
+   // println!("{s}");   // would not compile: s no longer owns anything
+   println!("{t}");      // t is the owner now
+
+*Why it's there:* ownership frees memory without a garbage collector and prevents
+use-after-free at compile time. Reading rule: a bare ``T`` in a signature takes
+ownership (the caller gives it up); ``&T`` / ``&mut T`` borrows (the caller keeps
+it).
+
+Lifetimes
+---------
+
+A lifetime like ``'a`` names *how long a reference is valid*. You mostly read
+them in signatures: ``fn first<'a>(xs: &'a [f64]) -> &'a f64`` says "the returned
+reference lives as long as the slice you passed in." Most lifetimes are *elided*
+(inferred); you only see explicit ones when the compiler cannot guess the
+relationship.
+
+*Why it's there:* lifetimes let the borrow checker prove a reference never
+outlives the data it points to — no dangling pointers. Reading rule: ``'a`` is
+not a value, it is a constraint; read which inputs and outputs share a lifetime
+and ignore the rest of the noise.
+
+Error Flow
+----------
+
+``Result<T, E>`` is "either a ``T`` (``Ok``) or an error ``E`` (``Err``)";
+``Option<T>`` is "either a ``T`` (``Some``) or nothing (``None``)". The ``?``
+operator means "unwrap the ``Ok`` / ``Some``, or return the ``Err`` / ``None``
+from this function early."
+
+.. code:: rust
+
+   fn load(path: &str) -> Result<String, std::io::Error> {
+       let text = std::fs::read_to_string(path)?;  // ? returns early on Err
+       Ok(text)
+   }
+
+``.unwrap()`` and ``.expect("msg")`` extract the value but **panic** on ``Err`` /
+``None`` — a crash point. Flag them in code meant to be robust.
+
+*Why it's there:* errors are ordinary values, so the type system forces you to
+handle (or explicitly defer with ``?``) every failure. Reading rule: ``?`` is a
+propagation shortcut; ``.unwrap()`` is a "trust me, cannot fail here" — and a
+place bugs hide.
+
+Traits & Generics
+-----------------
+
+A trait is a shared interface (close to a C++ concept or a Python protocol).
+Generics with ``where`` bounds say "any type that implements this trait."
+
+.. code:: rust
+
+   // signature sketch — `Float` comes from the num_traits crate
+   fn norm<T>(xs: &[T]) -> T
+   where
+       T: num_traits::Float,
+   {
+       xs.iter().fold(T::zero(), |a, &x| a + x * x).sqrt()
+   }
+
+- ``impl Trait`` in argument position = "some type implementing Trait", resolved
+  at compile time (*monomorphized* — one specialized copy per concrete type, zero
+  runtime cost).
+- ``dyn Trait`` (a *trait object*, usually ``Box<dyn Trait>`` or ``&dyn Trait``)
+  = dynamic dispatch through a vtable (one copy of the code, runtime
+  indirection).
+
+*Why it's there:* traits give polymorphism with a choice of cost model. Reading
+rule: ``impl`` / generic = compile-time, fast, larger binary; ``dyn`` = runtime
+dispatch, smaller binary, slight overhead.
+
+Pattern Matching
+----------------
+
+``match`` destructures a value against patterns, *exhaustively* (every case must
+be handled). ``if let`` and ``let ... else`` are shorthands for matching a single
+pattern.
+
+.. code:: rust
+
+   match result {
+       Ok(v) => use_it(v),
+       Err(e) => report(e),
+   }
+
+   let Some(x) = maybe else {
+       return;            // bail out if None
+   };
+
+*Why it's there:* exhaustiveness means adding a new enum variant forces you to
+update every match — the compiler finds the gaps. Reading rule: arms are tried
+top-to-bottom; ``_`` is the catch-all.
+
+Smart Pointers & Combinations
+-----------------------------
+
+- ``Box<T>`` — owned value on the heap (one owner).
+- ``Rc<T>`` / ``Arc<T>`` — shared ownership by reference counting (``Arc`` is the
+  thread-safe, atomic version).
+- ``RefCell<T>`` / ``Mutex<T>`` — interior mutability: mutate through a shared
+  reference, with the borrow rule enforced at *runtime* (``RefCell``, single
+  thread) or via a lock (``Mutex``, across threads).
+
+Read combinations inside-out. ``Arc<Mutex<T>>`` = "a ``T`` that several threads
+share (``Arc``) and take turns mutating under a lock (``Mutex``)" — the canonical
+shared-mutable-state-across-threads shape.
+
+*Why it's there:* these recover patterns that ownership alone forbids (sharing,
+cycles, mutate-through-shared), each naming its exact cost. Reading rule: the
+outer wrapper is the sharing model, the inner one is the data.
+
+Closures & Iterators
+--------------------
+
+A closure ``|x| x * x`` is an anonymous function that can capture variables. The
+trait it implements says how it captures: ``Fn`` (borrows), ``FnMut`` (mutably
+borrows), ``FnOnce`` (consumes). ``move`` forces it to take ownership of what it
+captures (common when spawning threads).
+
+Iterator chains are **lazy**: ``.iter().map(...).filter(...)`` builds a pipeline
+that does nothing until a *consumer* (``.collect()``, ``.sum()``, a ``for`` loop)
+drives it.
+
+.. code:: rust
+
+   let squares: Vec<f64> = xs.iter().map(|x| x * x).collect();
+   let total: f64 = squares.iter().sum();
+
+*Why it's there:* laziness lets chains fuse into a single pass with no
+intermediate allocations — as fast as a hand-written loop. Reading rule: find the
+consumer at the end of the chain; that is what actually runs the work.
+
+Macros
+------
+
+A trailing ``!`` marks a macro invocation, not a function call: ``println!``,
+``vec!``, ``assert_eq!``. Macros run at compile time and accept "syntax" a
+function cannot (format strings, variadic arguments). ``#[derive(Debug, Clone)]``
+is a *derive macro* that generates trait implementations for you.
+
+*Why it's there:* macros remove boilerplate the type system cannot. Reading rule:
+treat ``name!(...)`` as "expands to some code"; when you must see what, use
+``cargo expand`` (see ``tooling.rst``).
+
+Modules, Visibility & Turbofish
+-------------------------------
+
+``mod`` defines a module; ``pub`` exposes an item; ``use`` brings a path into
+scope. Paths use ``::`` (``std::sync::Arc``). The **turbofish** ``::<>`` pins a
+generic type the compiler cannot infer:
+
+.. code:: rust
+
+   let v = "42".parse::<i32>().unwrap();      // ::<i32> tells parse what to make
+   let xs = (0..n).collect::<Vec<f64>>();     // ::<Vec<f64>> picks the container
+
+*Why it's there:* explicit paths and visibility keep the module graph auditable.
+Reading rule: a turbofish always answers "what type?" for the call immediately
+before it.

--- a/skills/rust-explain/references/reading-vocabulary.rst
+++ b/skills/rust-explain/references/reading-vocabulary.rst
@@ -160,8 +160,10 @@ drives it.
    let total: f64 = squares.iter().sum();
 
 *Why it's there:* laziness lets chains fuse into a single pass with no
-intermediate allocations — as fast as a hand-written loop. Reading rule: find the
-consumer at the end of the chain; that is what actually runs the work.
+intermediate allocations — the *zero-cost-abstraction* intent is that they
+optimize down to roughly what a hand-written loop emits (an optimizer outcome,
+not a language guarantee). Reading rule: find the consumer at the end of the
+chain; that is what actually runs the work.
 
 Macros
 ------
@@ -185,7 +187,7 @@ generic type the compiler cannot infer:
 .. code:: rust
 
    let v = "42".parse::<i32>().unwrap();      // ::<i32> tells parse what to make
-   let xs = (0..n).collect::<Vec<f64>>();     // ::<Vec<f64>> picks the container
+   let xs = (0..n).map(|i| i as f64).collect::<Vec<f64>>();  // ::<Vec<f64>> picks the container
 
 *Why it's there:* explicit paths and visibility keep the module graph auditable.
 Reading rule: a turbofish always answers "what type?" for the call immediately

--- a/skills/rust-explain/references/reading-vocabulary.rst
+++ b/skills/rust-explain/references/reading-vocabulary.rst
@@ -11,7 +11,7 @@ Ownership & Borrowing
 
 ``T`` owns its value; ``&T`` borrows it (shared, read-only); ``&mut T`` borrows
 it exclusively (read-write). Assigning or passing an owned non-``Copy`` value
-*moves* it — the source can no longer be used.
+*moves* it — the source is *invalidated* and can no longer be used.
 
 .. code:: rust
 
@@ -143,9 +143,12 @@ Closures & Iterators
 --------------------
 
 A closure ``|x| x * x`` is an anonymous function that can capture variables. The
-trait it implements says how it captures: ``Fn`` (borrows), ``FnMut`` (mutably
-borrows), ``FnOnce`` (consumes). ``move`` forces it to take ownership of what it
-captures (common when spawning threads).
+trait it implements says how it can be *called*: ``Fn`` (via ``&self`` — only
+reads its captures, so callable repeatedly), ``FnMut`` (via ``&mut self`` — may
+mutate captures), ``FnOnce`` (via ``self`` — may move captures out, so callable
+once). ``move`` is separate: it forces the closure to *capture by value* (take
+ownership), common when spawning threads — a ``move`` closure can still be
+``Fn`` if its body only reads what it captured.
 
 Iterator chains are **lazy**: ``.iter().map(...).filter(...)`` builds a pipeline
 that does nothing until a *consumer* (``.collect()``, ``.sum()``, a ``for`` loop)
@@ -170,7 +173,7 @@ is a *derive macro* that generates trait implementations for you.
 
 *Why it's there:* macros remove boilerplate the type system cannot. Reading rule:
 treat ``name!(...)`` as "expands to some code"; when you must see what, use
-``cargo expand`` (see ``tooling.rst``).
+``cargo expand`` (see ``references/tooling.rst``).
 
 Modules, Visibility & Turbofish
 -------------------------------

--- a/skills/rust-explain/references/reading-vocabulary.rst
+++ b/skills/rust-explain/references/reading-vocabulary.rst
@@ -117,6 +117,11 @@ Smart Pointers & Combinations
 - ``Box<T>`` — owned value on the heap (one owner).
 - ``Rc<T>`` / ``Arc<T>`` — shared ownership by reference counting (``Arc`` is the
   thread-safe, atomic version).
+- ``Weak<T>`` — a *non-owning* ``Rc`` / ``Arc`` handle (from ``Rc::downgrade`` /
+  ``Arc::downgrade``). It does **not** keep the value alive; you call
+  ``.upgrade()`` to get an ``Option<Rc<T>>`` (or ``Option<Arc<T>>`` on the
+  ``Arc`` side) and find out whether it still exists. Its purpose is to
+  **break reference cycles** (see below).
 - ``RefCell<T>`` / ``Mutex<T>`` — interior mutability: mutate through a shared
   reference, with the borrow rule enforced at *runtime* (``RefCell``, single
   thread) or via a lock (``Mutex``, across threads).
@@ -125,9 +130,14 @@ Read combinations inside-out. ``Arc<Mutex<T>>`` = "a ``T`` that several threads
 share (``Arc``) and take turns mutating under a lock (``Mutex``)" — the canonical
 shared-mutable-state-across-threads shape.
 
-*Why it's there:* these recover patterns that ownership alone forbids (sharing,
-cycles, mutate-through-shared), each naming its exact cost. Reading rule: the
-outer wrapper is the sharing model, the inner one is the data.
+*Why it's there:* these recover patterns that ownership alone forbids — sharing,
+back-references, mutate-through-shared — each naming its exact cost. One caveat
+worth flagging when you see it: ``Rc`` / ``Arc`` do **not** manage *cycles* — a
+cycle of strong references never reaches refcount 0 and leaks, and ``Weak<T>``
+is precisely how correct code breaks it (Book §15.6, via
+``references/canonical-sources.rst``). Reading rule: the outer wrapper is the
+sharing model, the inner one is the data, and a ``Weak`` is a deliberately
+non-owning edge.
 
 Closures & Iterators
 --------------------

--- a/skills/rust-explain/references/tooling.rst
+++ b/skills/rust-explain/references/tooling.rst
@@ -138,6 +138,16 @@ The IDE language server. For *reading*, its highest-value features are:
 - **Go to definition / find references** — trace where a trait impl or value
   actually comes from.
 
+But it is **not** outside the trust boundary. By default rust-analyzer runs the
+project's ``build.rs`` and procedural macros (``cargo.buildScripts.enable`` and
+``procMacro.enable`` are on) so its analysis is accurate — which means merely
+*opening* an untrusted workspace can execute code. "Read-only navigation" is not
+read-only (rust-analyzer says as much in its own security note — see
+``references/canonical-sources.rst``). On untrusted code, read files statically
+instead, or open it in a disposable sandbox with build scripts, proc-macros, and
+check-on-save disabled and any project-supplied editor/tool configuration
+ignored.
+
 cargo doc & cargo expand
 ------------------------
 

--- a/skills/rust-explain/references/tooling.rst
+++ b/skills/rust-explain/references/tooling.rst
@@ -1,0 +1,92 @@
+Rust Tooling as a Teaching Aid
+==============================
+
+Let the tools do the mechanical work, then explain *why* their output is right.
+None of this needs a wrapper script — run the tools directly.
+
+cargo clippy — the free senior reviewer
+---------------------------------------
+
+``cargo clippy`` is Rust's idiom linter. Let it find the non-idiomatic code, then
+explain the reasoning instead of merely echoing the fix.
+
+.. code:: text
+
+   warning: the loop variable `i` is only used to index `v`
+    --> idiom.rs:3:14
+     |
+   3 |     for i in 0..v.len() {
+     |              ^^^^^^^^^^
+     |
+     = note: `#[warn(clippy::needless_range_loop)]` on by default
+   help: consider using an iterator
+     |
+   3 -     for i in 0..v.len() {
+   3 +     for <item> in &v {
+     |
+
+Teach it: "Clippy flags ``needless_range_loop`` (see the `clippy lint index
+<https://rust-lang.github.io/rust-clippy/master/index.html#needless_range_loop>`__).
+Indexing ``v[i]`` re-checks bounds every iteration and hides intent; ``for x in
+&v`` (equivalently ``v.iter()``) iterates the elements directly — clearer and
+bounds-check-free. This is the gap between *works* and *fluent*." For the
+idiomatic-rewrite mode, run clippy first, then walk each lint.
+
+rustc errors as teachers
+------------------------
+
+Feed the **code and the real compiler message together**, then explain what the
+rule protects against. Two canonical examples:
+
+.. code:: text
+
+   error[E0382]: borrow of moved value: `s`
+    --> move.rs:4:20
+     |
+   3 |     let t = s;
+     |             - value moved here
+   4 |     println!("{}", s);
+     |                    ^ value borrowed here after move
+
+"``s`` was *moved* into ``t``, so ``s`` is empty. The compiler is preventing two
+owners of one heap buffer — which would double-free at scope end. Fix: borrow
+(``&s``) if you only need to read, or ``.clone()`` if you genuinely need a second
+copy."
+
+.. code:: text
+
+   error[E0502]: cannot borrow `v` as mutable because it is also borrowed as immutable
+    --> borrow.rs:4:5
+     |
+   3 |     let first = &v[0];
+     |                  - immutable borrow occurs here
+   4 |     v.push(4);
+     |     ^^^^^^^^^ mutable borrow occurs here
+   5 |     println!("{first}");
+     |                ----- immutable borrow later used here
+
+"``push`` can reallocate the vector, which would leave ``first`` dangling. The
+borrow checker forbids a mutable borrow while a shared borrow is still live —
+exactly the iterator-invalidation bug that C++ allows silently."
+
+Use ``rustc --explain E0502`` for the long-form explanation of any error code.
+
+rust-analyzer — navigation
+--------------------------
+
+The IDE language server. For *reading*, its highest-value features are:
+
+- **Hover** — shows the inferred type of any expression. Rust infers most types,
+  so hover makes the invisible visible.
+- **Inlay hints** — inline type and parameter-name annotations.
+- **Go to definition / find references** — trace where a trait impl or value
+  actually comes from.
+
+cargo doc & cargo expand
+------------------------
+
+- ``cargo doc --open`` builds and opens the API docs for the crate *and all its
+  dependencies* — the fastest way to learn what an unfamiliar type offers.
+- ``cargo expand`` shows what a macro expands to. When ``#[derive(...)]`` or a
+  ``name!()`` macro is opaque, expand it to read the generated code (requires the
+  ``cargo-expand`` tool).

--- a/skills/rust-explain/references/tooling.rst
+++ b/skills/rust-explain/references/tooling.rst
@@ -26,10 +26,12 @@ explain the reasoning instead of merely echoing the fix.
      |
 
 Teach it: "Clippy flags ``needless_range_loop`` (see the `clippy lint index
-<https://rust-lang.github.io/rust-clippy/master/index.html#needless_range_loop>`__).
+<https://rust-lang.github.io/rust-clippy/stable/index.html#needless_range_loop>`__).
 Indexing ``v[i]`` re-checks bounds every iteration and hides intent; ``for x in
-&v`` (equivalently ``v.iter()``) iterates the elements directly — clearer and
-bounds-check-free. This is the gap between *works* and *fluent*." For the
+&v`` (equivalently ``v.iter()``) iterates the elements directly — clearer, and
+it lets the optimizer elide the per-iteration bounds check in the common case
+(bounds-check *elimination* is an LLVM optimization, not a language guarantee).
+This is the gap between *works* and *fluent*." For the
 idiomatic-rewrite mode, run clippy first, then walk each lint.
 
 rustc errors as teachers
@@ -48,10 +50,11 @@ rule protects against. Two canonical examples:
    4 |     println!("{}", s);
      |                    ^ value borrowed here after move
 
-"``s`` was *moved* into ``t``, so ``s`` is empty. The compiler is preventing two
-owners of one heap buffer — which would double-free at scope end. Fix: borrow
-(``&s``) if you only need to read, or ``.clone()`` if you genuinely need a second
-copy."
+"``s`` was *moved* into ``t``, so ``s`` is no longer usable — not emptied,
+**invalidated**: the value now lives in ``t`` and the compiler statically
+forbids touching ``s``. It is preventing two owners of one heap buffer — which
+would double-free at scope end. Fix: borrow (``&s``) if you only need to read,
+or ``.clone()`` if you genuinely need a second copy."
 
 .. code:: text
 

--- a/skills/rust-explain/references/tooling.rst
+++ b/skills/rust-explain/references/tooling.rst
@@ -7,15 +7,18 @@ None of this needs a wrapper script — run the tools directly.
 Trust boundary first
 --------------------
 
-``cargo check``, ``cargo clippy``, and ``cargo build`` all *compile* the crate,
-and compiling **runs** its ``build.rs`` build script and any procedural macros —
-arbitrary code executed at check time, even though you never run the resulting
-binary. On unfamiliar or untrusted code that is a real risk, not a theoretical
-one. Prefer ``rustc`` on a self-contained single file (no manifest, so no build
-script; with no proc-macro crate to link, no macro runs either). Reach for full
-Cargo only on code you trust, or inside a disposable sandbox — a throwaway
-container or VM you can discard. This is the same caution the skill applies to
-mode 2 ("Why does / doesn't this compile").
+Any Cargo command that *compiles* the crate — ``cargo check``, ``cargo clippy``,
+``cargo build``, ``cargo doc``, ``cargo expand``, ``cargo test``, ``cargo run`` —
+**runs** its ``build.rs`` build script and any procedural macros as part of
+compiling: arbitrary code executed before you ever run the binary. (``cargo
+expand`` is the sharpest case — expanding a proc-macro *is* executing it — and
+``cargo doc --open`` additionally launches a browser.) On unfamiliar or
+untrusted code that is a real risk, not a theoretical one. Prefer ``rustc`` on a
+self-contained single file (no manifest, so no build script; with no proc-macro
+crate to link, no macro runs either). Reach for full Cargo only on code you
+trust, or inside a disposable sandbox — a throwaway container or VM you can
+discard. This is the same caution the skill applies to mode 2 ("Why does /
+doesn't this compile").
 
 cargo clippy — the free senior reviewer
 ---------------------------------------
@@ -87,6 +90,27 @@ exactly the iterator-invalidation bug that C++ allows silently."
 
 Use ``rustc --explain E0502`` for the long-form explanation of any error code.
 
+Invoking ``rustc`` on a snippet: two defaults will mislead you. Bare
+``rustc file.rs`` assumes **edition 2015** and a **binary** crate, so modern
+syntax (``async``, ``let … else``) trips an edition error and any snippet
+without ``fn main`` trips ``error[E0601]`` — spurious errors that hide the
+borrow/lifetime one you actually want. Type-check a snippet like this instead:
+
+.. code:: text
+
+   rustc --edition 2021 --crate-type lib --emit=metadata snippet.rs -o "$(mktemp -d)/meta"
+
+``--edition`` should match the code (read it from ``Cargo.toml`` or ask the
+reader; use ``2024`` for the newest); ``--crate-type lib`` drops the ``fn main``
+requirement; ``--emit=metadata`` type-checks without producing — or running — a
+binary. Send the metadata to a throwaway temp dir rather than ``/dev/null``:
+``rustc`` writes its temp files *next to* the ``-o`` path, so a non-writable
+location (``/dev``) makes it abort with its own spurious error. Read the
+diagnostics it prints — a non-zero exit just means it found the error you were
+after. Code that pulls in external crates will not compile standalone: that
+needs the crate's own build, which means trusted code or a sandbox (see "Trust
+boundary first"), not raw ``rustc``.
+
 rust-analyzer — navigation
 --------------------------
 
@@ -106,3 +130,11 @@ cargo doc & cargo expand
 - ``cargo expand`` shows what a macro expands to. When ``#[derive(...)]`` or a
   ``name!()`` macro is opaque, expand it to read the generated code (requires the
   ``cargo-expand`` tool).
+
+Both compile the crate, so the **trust boundary above applies** — run them only
+on trusted code or in a sandbox. For *untrusted* code, the non-executing
+substitutes are: read the prebuilt docs on `docs.rs <https://docs.rs/>`__
+(already built in a sandbox) or the crate source directly instead of
+``cargo doc``; and read the macro's definition by hand (or expand it inside a
+throwaway container) instead of running ``cargo expand``, since expansion
+*executes* the macro.

--- a/skills/rust-explain/references/tooling.rst
+++ b/skills/rust-explain/references/tooling.rst
@@ -4,6 +4,19 @@ Rust Tooling as a Teaching Aid
 Let the tools do the mechanical work, then explain *why* their output is right.
 None of this needs a wrapper script — run the tools directly.
 
+Trust boundary first
+--------------------
+
+``cargo check``, ``cargo clippy``, and ``cargo build`` all *compile* the crate,
+and compiling **runs** its ``build.rs`` build script and any procedural macros —
+arbitrary code executed at check time, even though you never run the resulting
+binary. On unfamiliar or untrusted code that is a real risk, not a theoretical
+one. Prefer ``rustc`` on a self-contained single file (no manifest, so no build
+script; with no proc-macro crate to link, no macro runs either). Reach for full
+Cargo only on code you trust, or inside a disposable sandbox — a throwaway
+container or VM you can discard. This is the same caution the skill applies to
+mode 2 ("Why does / doesn't this compile").
+
 cargo clippy — the free senior reviewer
 ---------------------------------------
 

--- a/skills/rust-explain/references/tooling.rst
+++ b/skills/rust-explain/references/tooling.rst
@@ -7,18 +7,32 @@ None of this needs a wrapper script — run the tools directly.
 Trust boundary first
 --------------------
 
-Any Cargo command that *compiles* the crate — ``cargo check``, ``cargo clippy``,
-``cargo build``, ``cargo doc``, ``cargo expand``, ``cargo test``, ``cargo run`` —
-**runs** its ``build.rs`` build script and any procedural macros as part of
-compiling: arbitrary code executed before you ever run the binary. (``cargo
-expand`` is the sharpest case — expanding a proc-macro *is* executing it — and
-``cargo doc --open`` additionally launches a browser.) On unfamiliar or
-untrusted code that is a real risk, not a theoretical one. Prefer ``rustc`` on a
-self-contained single file (no manifest, so no build script; with no proc-macro
-crate to link, no macro runs either). Reach for full Cargo only on code you
-trust, or inside a disposable sandbox — a throwaway container or VM you can
-discard. This is the same caution the skill applies to mode 2 ("Why does /
-doesn't this compile").
+Compiling Rust runs code — and even *type-checking* can read your machine. Both
+are part of the trust boundary, in two layers:
+
+- **Any Cargo command that compiles** — ``cargo check``, ``cargo clippy``,
+  ``cargo build``, ``cargo doc``, ``cargo expand``, ``cargo test``, ``cargo
+  run`` — **runs** the crate's ``build.rs`` and any procedural macros as part of
+  compiling: arbitrary code, executed before you ever run a binary. (``cargo
+  expand`` is the sharpest case — expanding a proc-macro *is* executing it — and
+  ``cargo doc --open`` also launches a browser.)
+- **Plain ``rustc`` on a single file is lower-risk, not safe.** No manifest
+  means no ``build.rs``, and with no proc-macro crate to link, none of *those*
+  run — but ``rustc`` still expands **built-in** macros at compile time, and
+  ``env!``, ``option_env!``, ``include_str!``, ``include_bytes!``, and
+  ``include!`` read environment variables and files straight off your machine.
+  A snippet can fold them into a diagnostic, and the message — which this skill
+  tells you to read back — becomes an exfiltration channel. Verified with rustc
+  1.94.1: ``compile_error!(env!("HOME"))`` makes the compiler print your home
+  path, and ``compile_error!(include_str!("…/secret"))`` prints a file's
+  contents — no binary, build script, or proc-macro required.
+
+So for **untrusted** code, do not compile it on your own machine at all: read
+and explain it statically, or compile only inside a disposable sandbox with a
+**scrubbed environment** and no access to your home or repo, treating every
+diagnostic as attacker-controlled output. Reserve ``rustc`` / Cargo on the real
+machine for code you trust. This is the same caution the skill applies to mode 2
+("Why does / doesn't this compile").
 
 cargo clippy — the free senior reviewer
 ---------------------------------------
@@ -107,9 +121,11 @@ binary. Send the metadata to a throwaway temp dir rather than ``/dev/null``:
 ``rustc`` writes its temp files *next to* the ``-o`` path, so a non-writable
 location (``/dev``) makes it abort with its own spurious error. Read the
 diagnostics it prints — a non-zero exit just means it found the error you were
-after. Code that pulls in external crates will not compile standalone: that
-needs the crate's own build, which means trusted code or a sandbox (see "Trust
-boundary first"), not raw ``rustc``.
+after. Run this only on code you trust, or inside the scrubbed sandbox from
+"Trust boundary first": even this type-check expands ``env!`` / ``include_str!``,
+so a hostile snippet can leak local data into the very diagnostics you read
+back. Code that pulls in external crates will not compile standalone: that needs
+the crate's own build, which means trusted code or a sandbox, not raw ``rustc``.
 
 rust-analyzer — navigation
 --------------------------


### PR DESCRIPTION
## What

Adds **`rust-explain`** — a user-invocable teaching-assistant skill (`/rust-explain`) that explains and navigates Rust code for a reader with a computational-science background, where **correctness is the deliverable**.

## Why

Reading unfamiliar or generated Rust is the wall scientists hit first: ownership, lifetimes, `Arc<Mutex<T>>`, lazy iterator chains, and FFI all look opaque. This skill is a **tutor, not a gatekeeper** — it explains the *why*, never bare approval — and its highest-value job is a **silent-bug radar** for numeric kernels: the split between what the compiler catches (memory, concurrency) and what it cannot (your math).

## Structure

Lean `SKILL.md` + progressive-disclosure `.rst` references (matches the `go-secure` / `r-expert` house style):

| File | Role |
|---|---|
| `SKILL.md` | Stance, **comparison policy** (Rust on its own terms; analogies capped at C++/Python), four operating modes, routing |
| `references/reading-vocabulary.rst` | The Rust reading vocabulary — each with *what it does* + *why it's there* |
| `references/numeric-idioms.rst` | `ndarray`/`nalgebra`/`faer`/`polars`/`rayon`, FFI reading, **silent-bug radar** |
| `references/tooling.rst` | `cargo clippy` as the free reviewer, `rustc` errors as teachers, `rust-analyzer`, `cargo doc`/`expand` |

**No shipped scripts** — the skill drives `cargo clippy` / `rustc` / `cargo expand` directly, keeping a Rust toolchain out of this repo's CI.

## Operating modes

1. **Line-by-line annotate** — every borrow, lifetime, `?` explained inline
2. **Why does / doesn't this compile** — borrow-checker intuition, paired with the real `rustc` message
3. **Idiomatic rewrite + explain the diff** — clippy-driven, the gap between *works* and *fluent*
4. **Explain-on-demand** — one named construct, pitched at the reader's level

## Verification

Built via subagent-driven-development with full RED→GREEN testing (per `superpowers:writing-skills`):

- **Every embedded Rust example is compiler-verified** against rustc/clippy 1.94.1 — the `E0382`, `E0502`, and `needless_range_loop` blocks in `tooling.rst` are real compiler output, not paraphrase.
- **RED (no skill):** baseline agent caught the off-by-one but missed the parallel-reduction nondeterminism.
- **GREEN (with skill):** agent invoked the references (self-reported which it consulted), kept the tutor stance, respected the comparison policy, and additionally flagged the non-reproducible floating-point reduction — the exact gap the radar targets.
- `asctl repo-check` ✅ (56 skills) · changie fragment included (`Added`) · links resolve.

## Changelog

`Added`: new `rust-explain` skill.

## Review round — 2026-05-31

All review feedback is addressed; the branch is green and clean for approval.

- **18/18 inline review threads resolved.** Each comment was verified against current code before acting — 10 still-valid points fixed in `3d7f51a` (2 from @rudolfjs, 8 from Copilot), the other 8 already handled by earlier commits.
- **Maintainer comments:** mode 2 now *compiles/checks* (`cargo check` / `rustc`) to get the diagnostic instead of executing pasted code; the top-level numeric summary carries the full **safe / `unsafe`-FFI / never-caught** split so readers don't skip the unsafe audit.
- **Rust precision pass:** `as`-cast semantics corrected to distinguish narrowing (truncate), same-signedness widening (value-preserving), and signed→unsigned (`-1_i32 as usize` is `usize::MAX` — the classic silent `-1`-as-index bug); a non-compiling turbofish example fixed; iterator-perf and memory-safety wording tightened.
- **Independent review:** `/code-review` (Rust-accuracy + RST-consistency verifiers) plus **two Codex review rounds** — round 1 caught an over-broad "lossless" cast claim, round 2 returned clean after compile-checking the cast examples with `rustc`.
- **CI green:** `validate` (56 skills) · `check-changie-fragment` · `check-links` · `CodeRabbit`.

Only the required approving review remains before merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the "rust-explain" skill to help read, teach, and verify Rust code (vocabulary, numeric/scientific idioms, tooling workflows, and trust-boundary guidance).
* **Documentation**
  * Added comprehensive reference guides and registry/catalog entries describing reading vocabulary, numeric idioms, tooling safety, canonical sources, and verification practices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
