### PR TITLE
chore(changelog): add missing fragment for skill grouping plan

### DIFF
--- a/.changes/unreleased/Added-20260531102722-skill-grouping-plan.yaml
+++ b/.changes/unreleased/Added-20260531102722-skill-grouping-plan.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: Add skill grouping (strategy B) implementation plan
+time: 2026-05-31T10:27:22+00:00


### PR DESCRIPTION
Fixes the CI changelog check failure by adding the missing changelog fragment for the skill grouping plan.

---
*PR created automatically by Jules for task [3240235980103520568](https://jules.google.com/task/3240235980103520568) started by @rudolfjs*