### PR TITLE
chore: add changie fragment for skill-grouping plan

### DIFF
--- a/.changes/unreleased/Added-20260531-skill-grouping.yaml
+++ b/.changes/unreleased/Added-20260531-skill-grouping.yaml
@@ -1,0 +1,2 @@
+kind: Added
+body: Add plan for Claude-Code-only decision and cross-repo grouping contract


### PR DESCRIPTION
This commit addresses the failure in the `Changelog Check` CI job on the `chore/stack-skills` branch. The failure was caused by a missing changelog fragment since a new file was added (`docs/plans/2026-05-31-skill-grouping.md`) without the 'skip-changelog' label.

A new yaml fragment (`.changes/unreleased/Added-20260531-skill-grouping.yaml`) was added and the commit passes all tests including the `pixi run validate-skills` check.

---
*PR created automatically by Jules for task [13151781430120368148](https://jules.google.com/task/13151781430120368148) started by @rudolfjs*