### PR TITLE
chore: add changelog fragment for grouped skill layout support

### DIFF
--- a/.changes/unreleased/Added-20260531-111644.yaml
+++ b/.changes/unreleased/Added-20260531-111644.yaml
@@ -1,2 +1,2 @@
-kind: Changed
+kind: Added
 body: Add grouped skill layout support and doc updates

--- a/.changes/unreleased/Changed-20260531-111644.yaml
+++ b/.changes/unreleased/Changed-20260531-111644.yaml
@@ -1,0 +1,2 @@
+kind: Changed
+body: Add grouped skill layout support and doc updates


### PR DESCRIPTION
This PR adds the missing changelog fragment to the `chore/stack-skills` branch to resolve the CI "Changelog Check" failure. The fragment describes the changes related to adding grouped skill layout support and doc updates.

---
*PR created automatically by Jules for task [7765149336819191416](https://jules.google.com/task/7765149336819191416) started by @rudolfjs*