### PR TITLE
feat(jules-dispatch-creator): multiple Jules workflow families (#8)

### DIFF
--- a/.changes/unreleased/Added-20260601-203417.yaml
+++ b/.changes/unreleased/Added-20260601-203417.yaml
@@ -1,0 +1,3 @@
+kind: Added
+body: 'jules-dispatch-creator: support five trigger families (mention, label, scheduled, ci-workflow-run, issue-lifecycle) with per-family .rst references and a template-validation test; add the skill to the catalog and registry. Closes #8.'
+time: 2026-06-01T20:34:17.169213358+10:00

--- a/docs/skill-creation/skills-registry.mdx
+++ b/docs/skill-creation/skills-registry.mdx
@@ -21,6 +21,7 @@ Skills with no `scripts/` directory are pure prompt skills (SKILL.md + optional 
 | `go-secure` | — | Secure Go error handling and security patterns |
 | `husky` | — | Husky v9 git hooks management |
 | `jules` | Go | Jules AI coding session management — CLI binary (Go) |
+| `jules-dispatch-creator` | — | Generate tailored Jules GitHub Actions dispatch workflows (mention/label/scheduled/ci/issue-lifecycle triggers) |
 | `lefthook` | — | Lefthook git hooks management |
 | `lychee` | Bash | Fast link checker for documentation |
 | `quarto-alt-text` | — | Quarto document alt-text authoring |

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -40,6 +40,7 @@ RDL uses [nq-rdl/agent-extensions](https://github.com/nq-rdl/agent-extensions) t
 | [husky](../skills/husky/) | Git hooks with husky v9 — installation, hook authoring, CI integration. |
 | [lefthook](../skills/lefthook/) | Git hooks with Lefthook — Go-based, language-agnostic alternative to husky. |
 | [document-release](../skills/document-release/) | Post-ship documentation review — ensures README, CHANGELOG, CLAUDE.md, and project docs stay in sync. |
+| [jules-dispatch-creator](../skills/jules-dispatch-creator/) | Generate Jules GitHub Actions dispatch workflows tailored to a repo — five trigger families (mention, label, scheduled, ci-workflow-run, issue-lifecycle). |
 | [report-skill-issue](../skills/report-skill-issue/) | File bug reports for broken skills to their upstream repository. |
 | [skill-review](../skills/skill-review/) | Self-improvement loop — spawns a reviewer subagent to audit skills worked on in the current session. |
 | [cc-hook](../skills/cc-hook/) | Create, manage, and debug Claude Code hooks — all five hook types, the event lifecycle, the JSON output contract, and injection-safe context patterns. Invocable as `/cc-hook`. |

--- a/pixi.lock
+++ b/pixi.lock
@@ -90,7 +90,7 @@ packages:
 - pypi: ./
   name: agent-skills
   version: 0.1.0
-  sha256: 1d6cc02914384ef3eab4a43a19162ac55a0ad575b02d41e3be8f38b133d0eb8d
+  sha256: 5a19f802a79133818f8cd34faab2286499c86489551fd24d2a4dd89aa031088b
   requires_dist:
   - click>=8.0
   - strictyaml>=1.7.3
@@ -520,7 +520,7 @@ packages:
   license: MIT
   license_family: MIT
   purls:
-  - pkg:pypi/pyyaml?source=compressed-mapping
+  - pkg:pypi/pyyaml?source=hash-mapping
   size: 201616
   timestamp: 1770223543730
 - conda: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-h853b02a_0.conda

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ ruff = ">=0.8.0"
 ty = ">=0.0.1a9"
 zensical = ">=0.0.31,<0.0.32"
 pandoc = ">=3.9.0.2,<4"
+pyyaml = ">=6.0.3,<7"
 
 [tool.pixi.environments]
 default = { features = [], solve-group = "default" }

--- a/skills/jules-dispatch-creator/SKILL.md
+++ b/skills/jules-dispatch-creator/SKILL.md
@@ -172,8 +172,10 @@ Wait for targeted feedback or approval before writing any files.
 
 Once the user approves, write only the workflow file(s) requested in Phase 0.
 
-Read the relevant template from `templates/<workflow>-dispatch.yml.tmpl` (or
-`templates/jules-<family>.yml.tmpl` for the newer families), located in the same
+Read the relevant template from `templates/jules-<role>-dispatch.yml.tmpl`
+(mention-dispatch family, e.g. `jules-swe-dispatch.yml.tmpl`) or
+`templates/jules-<family>.yml.tmpl` (newer families, e.g.
+`jules-label-dispatch.yml.tmpl`, `jules-scheduled.yml.tmpl`), located in the same
 directory as this SKILL.md — not the project's working directory. Replace
 `[PROMPT CONTENT]` with the approved prompt, indented **12 spaces** (the YAML
 literal block scalar level in the template). Replace `[SECRET_NAME]` with the
@@ -185,8 +187,8 @@ YAML exactly — do not reformat, reorder, or simplify it.
 
 | Family | `@jules-*` guards | Issue context source | Actor authorisation | Concurrency |
 |--------|-------------------|----------------------|---------------------|-------------|
-| mention-dispatch | yes (all other handles) | `github.event.issue` via `gh` (+ `github.event.comment.body` for the triggering comment) | comment `author_association` OWNER/MEMBER | — |
-| label-dispatch | no | `github.event.issue` via `gh` | issue `author_association` OWNER/MEMBER | yes (per issue) |
+| mention-dispatch | yes (all other handles) | `steps.issue.outputs.*` (fetched via `gh`) + `github.event.comment.body` for the triggering comment | comment `author_association` OWNER/MEMBER | — |
+| label-dispatch | no | `steps.issue.outputs.*` (fetched via `gh`) | issue `author_association` OWNER/MEMBER | yes (per issue) |
 | scheduled | no | none | none (repo-controlled) | yes |
 | ci-workflow-run | no | none (CI failure context) | none | yes (per branch) |
 | issue-lifecycle | no | per-issue via github-script | per-issue `author_association` | yes (per closed issue) |

--- a/skills/jules-dispatch-creator/SKILL.md
+++ b/skills/jules-dispatch-creator/SKILL.md
@@ -134,7 +134,7 @@ family — the detail that used to live inline here.
  come from `${{ steps.issue.outputs.* }}` (fetched via `gh`), and the triggering
  comment from `${{ github.event.comment.body }}` directly (it is not extracted to
  a step output). label-dispatch: the issue via `${{ steps.issue.outputs.* }}`,
- no comment. scheduled: none. ci-workflow-run: the failing-run details. 
+ no comment. scheduled: none. ci-workflow-run: the failing-run details.
  issue-lifecycle: the unblocked issue via `${{ steps.issue.outputs.* }}`.]
 
 [Instructions — family-specific, ends with "open a PR when complete"]

--- a/skills/jules-dispatch-creator/SKILL.md
+++ b/skills/jules-dispatch-creator/SKILL.md
@@ -7,8 +7,10 @@ description: >-
   the Jules workflows", "set up Jules dispatch", "add Jules to my repo", "wire
   up Jules", "write Jules prompts for this project", "configure Jules for this
   repo", "integrate Jules", or "onboard Jules as a coding agent". Also applies
-  when the user is adding Jules to an existing GitHub project and needs tailored
-  workflow YAML files.
+  when adding Jules to an existing GitHub project that needs tailored workflow
+  YAML files, including multiple trigger families — comment mentions, issue
+  labels, scheduled/cron maintenance, CI-failure repair, and issue-lifecycle
+  automation.
 metadata:
   repo: https://github.com/nq-rdl/agent-skills
 ---
@@ -16,10 +18,23 @@ metadata:
 # Jules Dispatch Workflow Adapter
 
 Your job is to write Jules GitHub Actions dispatch workflows tailored to the
-current project. Jules is Google's async AI coding agent — each workflow fires
-when a GitHub issue comment mentions a `@jules-*` handle. The only thing that
-varies between projects is the `prompt:` block; the surrounding YAML is fixed
-boilerplate provided as template files in this skill.
+current project. Jules is Google's async AI coding agent. A workflow fires on
+some GitHub event, hands Jules a `prompt:` with enough context to work, and lets
+it open a PR. The only thing that varies between projects is the `prompt:` block;
+the surrounding YAML is fixed boilerplate provided as template files in this skill.
+
+Workflows are grouped into **trigger families** by the GitHub event that starts
+them. Each family has a template in `templates/` and a reference file in
+`references/` with the persona guidance, trigger mechanics, and authorisation
+model for that family:
+
+| Family | Trigger | Use for | Reference |
+|--------|---------|---------|-----------|
+| mention-dispatch | `issue_comment` + `@jules-<handle>` | human-initiated, free-form tasks on an issue | `references/mention-dispatch.rst` |
+| label-dispatch | `issues: [labeled]` | categorised, semi-automated triage | `references/label-dispatch.rst` |
+| scheduled | `schedule` + `workflow_dispatch` | repo-controlled recurring maintenance | `references/scheduled.rst` |
+| ci-workflow-run | `workflow_run` (failure) | automatic repair of a failing pipeline | `references/ci-workflow-run.rst` |
+| issue-lifecycle | `issues: [closed]` | dependency-driven follow-on work | `references/issue-lifecycle.rst` |
 
 Work through the following phases.
 
@@ -29,14 +44,15 @@ Work through the following phases.
 
 Before reading the codebase, ask the user two quick questions:
 
-1. **Which workflow(s)?** Available: `swe`, `security`, `docs`, `infra`,
-   `ci-review`. If the user doesn't specify, generate all applicable ones.
-2. **Secret name** — What GitHub Actions secret holds the Jules API key?
-   (Each team member typically has their own token; name it accordingly, e.g.
+1. **Which workflow(s)?** Choose by trigger family (see the table above). Within
+   `mention-dispatch`, also choose roles: `swe`, `security`, `docs`, `infra`. If
+   the user doesn't specify, generate the families and roles that apply to the
+   project.
+2. **Secret name** — What GitHub Actions secret holds the Jules API key? (Each
+   team member typically has their own token; name it accordingly, e.g.
    `JK_JULES_API`, `AB_JULES_API`.)
 
-If the user doesn't specify which workflows, generate all of them. Store the
-secret name — it replaces `[SECRET_NAME]` in every template.
+Store the secret name — it replaces `[SECRET_NAME]` in every template.
 
 ---
 
@@ -99,17 +115,10 @@ context to work autonomously. The goal is to teach Jules *how to orient itself*,
 not to pre-load it with a snapshot of the codebase. Snapshots go stale; process
 doesn't.
 
-### Quick reference by role
-
-| Role | Key constraint | Key reference doc |
-|------|---------------|-------------------|
-| `swe` | Keep sparse — CLAUDE.md covers conventions | `CLAUDE.md`, `ARCHITECTURE.md` |
-| `security` | Describe risk patterns, not specific files | `ARCHITECTURE.md`, `CLAUDE.md` |
-| `docs` | Read code first, verify every claim | `ARCHITECTURE.md`, `DESIGN.md`, `CONTRIBUTING.md` |
-| `infra` | No live infra access — repo-local validation only | `ARCHITECTURE.md`, `CONTRIBUTING.md` |
-| `ci-review` | Triggered by CI failure, not a human mention; uses `workflow_run` trigger | CI workflow definitions, `CONTRIBUTING.md` |
-
-See the per-role sections below for full guidance on each.
+**For each family you are generating, read `references/<family>.rst` before
+drafting the prompt.** Each reference carries the persona guidance, trigger
+mechanics, authorisation model, and instruction-block expectations for that
+family — the detail that used to live inline here.
 
 ### Prompt structure (follow this order for every workflow)
 
@@ -118,21 +127,14 @@ See the per-role sections below for full guidance on each.
 
 [Orientation process or key conventions — stable, non-stale guidance]
 
-[Role-specific reference material — see per-role guidance below]
+[Role-specific reference material — see the family reference]
 
-[Issue context — injected by GitHub Actions, keep interpolations verbatim]
-## GitHub Issue #${{ github.event.issue.number }}: ${{ steps.issue.outputs.title }}
+[Event context — injected by GitHub Actions, keep interpolations verbatim.
+ The shape depends on the family: an issue + triggering comment for
+ mention-dispatch; the issue for label-dispatch; none for scheduled; the
+ failing-run details for ci-workflow-run; the unblocked issue for issue-lifecycle.]
 
-Labels: ${{ steps.issue.outputs.labels }}
-
-${{ steps.issue.outputs.body }}
-
-[Triggering comment — keep verbatim, always last]
-## Triggering comment
-
-${{ github.event.comment.body }}
-
-[Instructions — role-specific, ends with "open a PR when complete"]
+[Instructions — family-specific, ends with "open a PR when complete"]
 ```
 
 ### Instruction density
@@ -144,192 +146,17 @@ actually needs for that role:
   Over-specifying the instructions poisons context when the issue asks for
   something slightly different. A brief "implement the request; open a PR" is
   enough.
-- **Security / docs / infra** — use structured constraints. These roles have
-  narrower operational boundaries and Jules benefits from explicit expectations:
-  what it is allowed to do, what it must not do, what output format is expected,
-  and a clear action to close with ("open a pull request").
-
----
-
-### SWE prompt guidance
-
-If a comprehensive `CLAUDE.md` exists: keep the prompt thin. Reference CLAUDE.md
-explicitly — Jules will read it. Don't reproduce its contents in the prompt;
-doing so creates a second source of truth that will diverge from the real one.
-
-**Orientation notes must point to documents, not encode facts.** If you discover
-during Phase 1 that the project has a non-obvious layout (e.g. Python source
-under `backend/` rather than at the repo root), resist the temptation to encode
-that fact directly in the prompt. Instead, point Jules to the stable document
-that describes it — `docs/ARCHITECTURE.md`, or wherever the layout is
-documented. A prompt that says "all Python source lives under `backend/`"
-becomes incorrect the moment a PR moves things and the docs are updated. A
-prompt that says "read `docs/ARCHITECTURE.md` for current project layout"
-remains accurate indefinitely, and Jules benefits automatically from every
-docs improvement the docs workflow makes. This principle applies to any
-structural fact that could change: entry points, module names, directory
-conventions. If the structural documentation doesn't yet exist or is stale,
-file a GitHub issue — don't encode the correction in the system prompt.
-
-```
-You are a Software Engineer working on [project name] — [one-sentence description].
-
-Read `CLAUDE.md` at the repo root for the authoritative project layout, commands,
-testing strategy, and conventions before starting work. Read `docs/ARCHITECTURE.md`
-for the current system topology and entry points.
-
-[Add only what neither CLAUDE.md nor ARCHITECTURE.md covers — e.g. a
-project-specific pattern that matters for this workflow but isn't documented
-anywhere stable.]
-
-## GitHub Issue ...
-## Triggering comment
-## Instructions
-Implement the request described in the issue. Open a pull request when complete.
-```
-
-If no CLAUDE.md exists: include enough pattern-based context for Jules to
-navigate (architecture style, key directories, test runner) — but prefer
-conventions over exhaustive file lists, which go stale.
-
----
-
-### Security prompt guidance
-
-Describe risk *patterns* tied to this stack, not specific files. The issue tells
-Jules where to focus; the system prompt should help Jules recognise *what kind of
-threats* to look for, not prescribe which files to audit. Specific file paths
-become incorrect as the codebase evolves.
-
-Point Jules to `docs/ARCHITECTURE.md` (and `CLAUDE.md` if it exists) for
-orientation — the same principle applies here as for SWE: encode the *process*
-of reading stable documents, not the structural facts those documents contain.
-A system prompt that says "read `docs/ARCHITECTURE.md` to understand current
-structure" remains accurate after a refactor; one that names specific source
-directories will lie to Jules from the moment those directories are moved.
-
-Pattern-based guidance looks like:
-
-- "This stack generates SQL from config files — SQL injection from config values
-  is a risk class to assess."
-- "User-controlled strings are used to construct filesystem paths — path traversal
-  is a risk class."
-- "Credentials are passed through environment variables — check for leakage into
-  logs or error responses."
-
-Keep the severity model and PR conventions stable. Let Jules discover which files
-are affected from the issue and by reading the code.
-
-**Instructions block for security** should specify:
-- What to produce (findings as PR comments or a report file)
-- Severity classification expected (e.g. critical / high / medium / low)
-- Whether to fix or only report
-- "Open a pull request with your findings when complete."
-
----
-
-### Docs prompt guidance
-
-The user maintains three structural doc files across their projects. If any are
-present (discovered in Phase 1), reference them explicitly in the prompt — they
-are stable anchors, not ephemeral `docs/` subpaths:
-
-- **`ARCHITECTURE.md`** — system topology, infra, languages, setup
-- **`DESIGN.md`** — component layout, design decisions
-- **`CONTRIBUTING.md`** — contribution patterns; often contains LLM-specific
-  conventions Jules should follow
-
-Do NOT list ad-hoc files under `docs/`. Those paths change frequently; listing
-them leads Jules to edit the wrong files or create duplicates.
-
-Instead, describe the *process* Jules should follow:
-
-1. **Read source code first** to understand the current state of whatever the
-   issue asks about. Treat existing docs as potentially outdated until verified.
-2. **Verify every claim against code** before writing — no aspirational statements,
-   no guesses about behaviour.
-3. **Writing standards** — tone, tense, heading style, commit prefix (`docs:`).
-
-**Instructions block for docs** should specify:
-- Files in scope (the structural files above if present, plus `README.md`;
-  avoid open-ended lists)
-- Commit prefix convention (`docs:`)
-- "Open a pull request when complete."
-
----
-
-### Infra prompt guidance
-
-Infrastructure changes carry real operational risk. The infra prompt must give
-Jules a hard boundary: it writes and validates IaC code in the repository, but it
-has **no access to live infrastructure** — no CLI calls, no API calls, no
-applying changes.
-
-The prompt should include:
-
-- **Architecture context** — stable overview of the infra topology (tools,
-  platforms, directory layout). Reference `ARCHITECTURE.md` if present.
-- **Per-tool conventions** — naming patterns, module structure, coding standards
-  for each IaC tool in use (Ansible, Terraform, Helm, etc.). Reference
-  `CONTRIBUTING.md` if it covers these.
-- **Constraints** (make these explicit):
-  - No live infra access — no `terraform apply`, no `ansible-playbook`, no
-    `kubectl apply`
-  - Validation is repo-local only: `terraform validate`, `ansible-lint`,
-    `helm lint`, etc.
-- **Implementation expectations**:
-  - Follow existing patterns in the repo before introducing new abstractions
-  - Validate all changes before committing
-- **Instructions block for infra** should end with:
-  "Open a pull request with the implementation when complete."
-
----
-
-### CI Review prompt guidance
-
-The `ci-review` role is fundamentally different from the other four roles: it is
-triggered by a **CI failure event**, not a human mention in a comment. This means:
-
-- **No issue context** — there is no issue number, title, body, or labels to
-  inject. The prompt receives the failing workflow name, failed job names, and
-  a run URL instead.
-- **No `@jules-ci-review` mention guard** — the `workflow_run` trigger cannot
-  collide with `issue_comment`-based `!contains` guards. Do NOT add
-  `!contains(github.event.comment.body, '@jules-ci-review')` to other templates.
-- **Different placeholders** — the template uses three placeholders:
-  `[SECRET_NAME]`, `[PROMPT CONTENT]`, and `[CI_WORKFLOW_NAMES]` (a JSON array
-  of workflow name strings, e.g. `["CI", "Tests"]`).
-
-**Loop prevention** — The template's `if` guard excludes `main` and any branch
-starting with `jules/`. If Jules creates fix branches with a `jules/` prefix, its
-own PRs will not re-trigger the workflow. Verify this convention holds for the
-Jules action version in use.
-
-The prompt should include:
-
-- **Project context** — enough for Jules to navigate the repo (same as other roles).
-- **CI workflow descriptions** — what each monitored workflow does and how to
-  reproduce its failure locally (e.g. `pixi run validate-skills`).
-- **Failure context** — injected by GitHub Actions; keep these interpolations verbatim:
-  - `${{ github.event.workflow_run.name }}` — the failing workflow name
-  - `${{ github.event.workflow_run.head_branch }}` — the branch that triggered it
-  - `${{ steps.failure.outputs.failed_jobs }}` — comma-separated failed job names
-  - `${{ steps.failure.outputs.run_url }}` — link to the failed run
-- **Diagnosis process** — branch on the workflow name to guide Jules toward the
-  right reproduction and fix strategy for each CI check.
-- **Fix constraints** — minimal change only; do not modify validation rules unless
-  they are the root cause.
-
-**Instructions block for ci-review** should end with:
-"Open a pull request with the fix when complete."
-
----
+- **Security / docs / infra / label / scheduled / issue-lifecycle** — use
+  structured constraints. These roles have narrower operational boundaries and
+  Jules benefits from explicit expectations: what it is allowed to do, what it
+  must not do, what output format is expected, and a clear action to close with
+  ("open a pull request").
 
 ### Presenting the drafts
 
 Show all requested draft prompts to the user before writing any files. For each:
 
-- State what role/persona was assigned.
+- State what family/role/persona was assigned.
 - Flag any decisions where the best choice was unclear.
 - Highlight gaps (e.g. no writing standards found in existing docs — ask the user
   to describe their preferred style before continuing).
@@ -342,41 +169,45 @@ Wait for targeted feedback or approval before writing any files.
 
 Once the user approves, write only the workflow file(s) requested in Phase 0.
 
-Read the relevant template from `templates/<workflow>-dispatch.yml.tmpl`,
-located in the same directory as this SKILL.md — not the project's working
-directory.
-Replace `[PROMPT CONTENT]` with the approved prompt, indented **12 spaces** (the
-YAML literal block scalar level in the template). Replace `[SECRET_NAME]` with
-the secret name from Phase 0. Reproduce all other YAML exactly — do not reformat,
-reorder, or simplify it.
+Read the relevant template from `templates/<workflow>-dispatch.yml.tmpl` (or
+`templates/jules-<family>.yml.tmpl` for the newer families), located in the same
+directory as this SKILL.md — not the project's working directory. Replace
+`[PROMPT CONTENT]` with the approved prompt, indented **12 spaces** (the YAML
+literal block scalar level in the template). Replace `[SECRET_NAME]` with the
+secret name from Phase 0, and any family-specific placeholders (e.g.
+`[TRIGGER_LABEL]`, `[CRON_SCHEDULE]`, `[CI_WORKFLOW_NAMES]`). Reproduce all other
+YAML exactly — do not reformat, reorder, or simplify it.
 
-### `if` condition rules — apply to every template
+### Trigger-family rules at a glance
 
-Every workflow guards against **all other `@jules-*` handles** to prevent
-double-firing when multiple handles appear in one comment. The current handle set
-is: `@jules-swe`, `@jules-security`, `@jules-docs`, `@jules-infra`.
+| Family | `@jules-*` guards | Issue context source | Actor authorisation | Concurrency |
+|--------|-------------------|----------------------|---------------------|-------------|
+| mention-dispatch | yes (all other handles) | `github.event.comment` | `author_association` OWNER/MEMBER | — |
+| label-dispatch | no | `github.event.issue` | issue `author_association` OWNER/MEMBER | — |
+| scheduled | no | none | none (repo-controlled) | yes |
+| ci-workflow-run | no | none (CI failure context) | none | yes (per branch) |
+| issue-lifecycle | no | per-issue via github-script | per-issue `author_association` | — |
 
-- `author_association` must be `OWNER` or `MEMBER` only — no `COLLABORATOR`.
-- The correct pattern for the existing workflows:
-  - **SWE**: triggers on `@jules-swe`; guards against security, docs, infra
-  - **Security**: triggers on `@jules-security`; guards against swe, docs, infra
-  - **Docs**: triggers on `@jules-docs`; guards against swe, security, infra
-  - **Infra**: triggers on `@jules-infra`; guards against swe, security, docs
+**Do not add `@jules-*` guards to any family except mention-dispatch.** The
+`workflow_run`, `schedule`, and `issues` triggers cannot collide with
+`issue_comment` mentions, so a guard there is meaningless.
 
-**Maintenance note — adding a new `issue_comment` workflow:** Every time a new
-`@jules-*` handle is added for an `issue_comment`-triggered workflow, all
-*existing* `issue_comment` templates must be updated with a new `!contains` guard
-for the new handle. The templates in `templates/` are the canonical
-source — update them, then regenerate any deployed workflows from them.
+### Handle-guard rules — mention-dispatch only
 
-**Exception — `ci-review`:** The `jules-ci-review-dispatch.yml.tmpl` template
-uses `workflow_run` and does NOT use `!contains` guards. Do NOT add a guard for
-`@jules-ci-review` to the other templates.
+Every `issue_comment` template triggers on its own handle and guards
+(`!contains`) against **every other** `@jules-*` handle in the canonical set, so a
+comment naming two handles dispatches only the intended one. The canonical handle
+set and the maintenance rule (and how the test enforces it) live in
+`references/mention-dispatch.rst` — treat that file plus the `templates/` files as
+the single source of truth. When you add a new `issue_comment` handle, update the
+`!contains` guard in *every* mention-dispatch template and the `MENTION_HANDLES`
+tuple in `tests/skills/test_jules_dispatch_creator_templates.py`.
 
-### Injection prevention — all issue_comment templates use this
+### Injection prevention — issue_comment and label templates
 
-Every template uses a randomised heredoc delimiter (`openssl rand -hex 8`) when
-writing `title` and `body` to `$GITHUB_OUTPUT`. This prevents a crafted issue
-title or body containing a fixed delimiter string on its own line from breaking
-out of the heredoc and injecting arbitrary output. Never use a fixed string like
-`ISSUE_EOF` as a heredoc delimiter in these workflows.
+Templates that read an issue `title`/`body` in a bash step and write them to
+`$GITHUB_OUTPUT` use a randomised heredoc delimiter (`openssl rand -hex 8`). This
+prevents a crafted issue title or body from breaking out of the heredoc and
+injecting arbitrary output. Never use a fixed string like `ISSUE_EOF`. The
+`issue-lifecycle` template avoids the issue entirely by reading issue details
+through `actions/github-script` (`core.setOutput` is injection-safe).

--- a/skills/jules-dispatch-creator/SKILL.md
+++ b/skills/jules-dispatch-creator/SKILL.md
@@ -130,9 +130,12 @@ family — the detail that used to live inline here.
 [Role-specific reference material — see the family reference]
 
 [Event context — injected by GitHub Actions, keep interpolations verbatim.
- The shape depends on the family: an issue + triggering comment for
- mention-dispatch; the issue for label-dispatch; none for scheduled; the
- failing-run details for ci-workflow-run; the unblocked issue for issue-lifecycle.]
+ The shape depends on the family. mention-dispatch: the issue title/body/labels
+ come from `${{ steps.issue.outputs.* }}` (fetched via `gh`), and the triggering
+ comment from `${{ github.event.comment.body }}` directly (it is not extracted to
+ a step output). label-dispatch: the issue via `${{ steps.issue.outputs.* }}`,
+ no comment. scheduled: none. ci-workflow-run: the failing-run details. 
+ issue-lifecycle: the unblocked issue via `${{ steps.issue.outputs.* }}`.]
 
 [Instructions — family-specific, ends with "open a PR when complete"]
 ```
@@ -182,11 +185,11 @@ YAML exactly — do not reformat, reorder, or simplify it.
 
 | Family | `@jules-*` guards | Issue context source | Actor authorisation | Concurrency |
 |--------|-------------------|----------------------|---------------------|-------------|
-| mention-dispatch | yes (all other handles) | `github.event.comment` | `author_association` OWNER/MEMBER | — |
-| label-dispatch | no | `github.event.issue` | issue `author_association` OWNER/MEMBER | — |
+| mention-dispatch | yes (all other handles) | `github.event.issue` via `gh` (+ `github.event.comment.body` for the triggering comment) | comment `author_association` OWNER/MEMBER | — |
+| label-dispatch | no | `github.event.issue` via `gh` | issue `author_association` OWNER/MEMBER | yes (per issue) |
 | scheduled | no | none | none (repo-controlled) | yes |
 | ci-workflow-run | no | none (CI failure context) | none | yes (per branch) |
-| issue-lifecycle | no | per-issue via github-script | per-issue `author_association` | — |
+| issue-lifecycle | no | per-issue via github-script | per-issue `author_association` | yes (per closed issue) |
 
 **Do not add `@jules-*` guards to any family except mention-dispatch.** The
 `workflow_run`, `schedule`, and `issues` triggers cannot collide with

--- a/skills/jules-dispatch-creator/references/ci-workflow-run.rst
+++ b/skills/jules-dispatch-creator/references/ci-workflow-run.rst
@@ -22,9 +22,11 @@ Loop prevention
 
 The template's ``if`` guard excludes ``main`` and any branch starting with
 ``jules/``. If Jules creates fix branches with a ``jules/`` prefix, its own PRs
-will not re-trigger the workflow. The ``concurrency`` group ensures only one Jules
-session runs per branch at a time. Verify this convention holds for the
-jules-action version in use.
+will not re-trigger the workflow. The ``concurrency`` group
+(``cancel-in-progress: true``) ensures only one Jules session runs per branch at
+a time, with a newer CI-failure run superseding an older, still-running one —
+unlike the issue-driven families, which queue with ``cancel-in-progress: false``.
+Verify this convention holds for the jules-action version in use.
 
 Prompt contents
 ---------------

--- a/skills/jules-dispatch-creator/references/ci-workflow-run.rst
+++ b/skills/jules-dispatch-creator/references/ci-workflow-run.rst
@@ -1,0 +1,52 @@
+CI-workflow-run workflows
+=========================
+
+The ``ci-workflow-run`` family is triggered by a **CI failure event**, not a human
+mention. It fires when a monitored workflow completes with a failure and asks
+Jules to diagnose and fix it. Template: ``jules-ci-review-dispatch.yml.tmpl``.
+
+This is fundamentally different from the mention-dispatch family:
+
+- **No issue context** — there is no issue number, title, body, or labels to
+  inject. The prompt receives the failing workflow name, failed job names, and a
+  run URL instead.
+- **No** ``@jules-ci-review`` **mention guard** — the ``workflow_run`` trigger
+  cannot collide with ``issue_comment``-based ``!contains`` guards. Do **not** add
+  ``!contains(github.event.comment.body, '@jules-ci-review')`` to any template.
+- **Different placeholders** — the template uses three: ``[SECRET_NAME]``,
+  ``[PROMPT CONTENT]``, and ``[CI_WORKFLOW_NAMES]`` (a JSON array of workflow name
+  strings, e.g. ``["Validate Skills", "Changelog Check"]``).
+
+Loop prevention
+---------------
+
+The template's ``if`` guard excludes ``main`` and any branch starting with
+``jules/``. If Jules creates fix branches with a ``jules/`` prefix, its own PRs
+will not re-trigger the workflow. The ``concurrency`` group ensures only one Jules
+session runs per branch at a time. Verify this convention holds for the
+jules-action version in use.
+
+Prompt contents
+---------------
+
+The prompt should include:
+
+- **Project context** — enough for Jules to navigate the repo (same as other
+  families).
+- **CI workflow descriptions** — what each monitored workflow does and how to
+  reproduce its failure locally (e.g. ``pixi run validate-skills``).
+- **Failure context** — injected by GitHub Actions; keep these interpolations
+  verbatim:
+
+  - ``${{ github.event.workflow_run.name }}`` — the failing workflow name
+  - ``${{ github.event.workflow_run.head_branch }}`` — the branch that triggered it
+  - ``${{ steps.failure.outputs.failed_jobs }}`` — comma-separated failed job names
+  - ``${{ steps.failure.outputs.run_url }}`` — link to the failed run
+
+- **Diagnosis process** — branch on the workflow name to guide Jules toward the
+  right reproduction and fix strategy for each CI check.
+- **Fix constraints** — minimal change only; do not modify validation rules unless
+  they are the root cause.
+
+The instructions block should end with "Open a pull request with the fix when
+complete."

--- a/skills/jules-dispatch-creator/references/issue-lifecycle.rst
+++ b/skills/jules-dispatch-creator/references/issue-lifecycle.rst
@@ -1,0 +1,58 @@
+Issue-lifecycle workflows
+=========================
+
+Issue-lifecycle workflows fire on ``issues: [closed]``. They are for
+**dependency-driven follow-on work**: when an issue is closed, find the issues it
+was blocking that are now ready and start Jules on each. Template:
+``jules-issue-lifecycle.yml.tmpl``.
+
+Read this file when generating an issue-lifecycle workflow.
+
+Two-job structure
+-----------------
+
+The template has two jobs:
+
+1. ``detect-unblocked`` — finds open issues that were blocked by the just-closed
+   issue and whose blockers are now all closed, and outputs a JSON matrix of their
+   numbers (plus a ``found`` flag).
+2. ``implement`` — runs only when ``found == 'true'``; fans out over the matrix and
+   invokes Jules once per unblocked issue.
+
+Detection (no phantom action)
+-----------------------------
+
+The upstream ``unblocked-issues`` example references
+``google-labs-code/on-unblocked@v1`` (and ``google-labs-code/jules-invoke@v1``).
+Neither is a real published action — ``google-labs-code/jules-action`` is a single
+composite action, which RDL forks and pins as ``nq-rdl/jules-action``. So the
+detect job implements the logic **inline** with ``actions/github-script@v7``
+(real, pinnable, already used by ``ci-workflow-run``) rather than referencing a
+non-existent action.
+
+The default detection encodes a ``blocked by #N`` / ``depends on #N`` convention:
+it scans open issues, keeps those whose body references the just-closed issue, and
+confirms every referenced blocker is closed before marking the issue ready. Adjust
+the regex to match the project's actual dependency-tracking convention (some teams
+use task lists, a ``Depends-On:`` trailer, or a project board).
+
+Authorisation
+-------------
+
+Authorise **per unblocked issue** on its ``author_association`` (OWNER/MEMBER).
+``gh issue view`` does not expose ``author_association``, so the ``implement`` job
+fetches each issue through the REST API via ``actions/github-script``
+(``github.rest.issues.get``) and gates the Jules invocation on the result.
+``github-script``'s ``core.setOutput`` is injection-safe, so no randomised bash
+heredoc is needed here.
+
+Do **not** add ``@jules-*`` handle guards; those belong only to mention-dispatch.
+
+Prompt contents
+---------------
+
+The prompt receives an unblocked issue's title and body
+(``${{ steps.issue.outputs.title }}`` / ``body``). Follow the standard ordering in
+``SKILL.md`` and end the instructions block with "open a pull request when
+complete." Keep orientation pointed at stable documents, as with the other
+families.

--- a/skills/jules-dispatch-creator/references/issue-lifecycle.rst
+++ b/skills/jules-dispatch-creator/references/issue-lifecycle.rst
@@ -48,6 +48,27 @@ heredoc is needed here.
 
 Do **not** add ``@jules-*`` handle guards; those belong only to mention-dispatch.
 
+Concurrency and the closing actor
+---------------------------------
+
+A workflow-level ``concurrency`` group keyed on the closed issue
+(``jules-issue-lifecycle-${{ github.event.issue.number }}``,
+``cancel-in-progress: false``) serialises the pipeline so a rapid
+close/reopen/close on the same issue does not launch overlapping detection
+sweeps. The ``implement`` job's matrix uses ``fail-fast: false`` so that a failed
+dispatch on one unblocked issue does not cancel the others — each is independent
+work.
+
+The ``detect-unblocked`` job runs on **every** ``issues: closed`` event, with no
+guard on who closed the issue. This is deliberate: gating the scan on the closing
+issue's author would skip legitimate cases where closing an *externally* authored
+issue (e.g. a community bug report) unblocks internal work. Jules is never invoked
+incorrectly — the per-issue ``author_association`` check still gates every actual
+invocation — but be aware that a Triage-role actor can drive repeated (read-only)
+API scans by closing issues. If that denial-of-wallet surface matters for your
+repo, add a job-level ``if:`` on ``github.event.issue.author_association`` or a
+``github.actor`` allowlist to ``detect-unblocked``.
+
 Prompt contents
 ---------------
 

--- a/skills/jules-dispatch-creator/references/label-dispatch.rst
+++ b/skills/jules-dispatch-creator/references/label-dispatch.rst
@@ -49,7 +49,10 @@ Do **not** add ``@jules-*`` handle guards; those belong only to mention-dispatch
 Prompt structure
 ----------------
 
-Issue context comes from ``github.event.issue.*`` (there is no triggering comment).
+Issue context (title, body, labels) is fetched via ``gh`` in the ``Fetch issue
+context`` step and injected through ``${{ steps.issue.outputs.* }}`` (there is no
+triggering comment; ``github.event.issue.*`` only supplies trigger metadata such
+as the issue number and ``author_association`` for the gate).
 Otherwise follow the standard ordering in ``SKILL.md``: role + project overview,
 orientation process, role-specific reference material, the injected issue context,
 then the instructions block.

--- a/skills/jules-dispatch-creator/references/label-dispatch.rst
+++ b/skills/jules-dispatch-creator/references/label-dispatch.rst
@@ -1,0 +1,53 @@
+Label-dispatch workflows
+========================
+
+Label-dispatch workflows fire on ``issues: [labeled]`` when a chosen label is
+applied to an issue. They are for **categorised, semi-automated triage**: instead
+of mentioning a handle in a comment, a maintainer applies a label and Jules acts.
+Template: ``jules-label-dispatch.yml.tmpl``.
+
+Read this file when generating a label-dispatch workflow.
+
+Trigger and label
+-----------------
+
+The trigger is ``issues: [labeled]``; the job guard is
+``github.event.label.name == '[TRIGGER_LABEL]'``. Choose ``[TRIGGER_LABEL]`` to
+match the intent:
+
+- ``jules`` — a generic "Jules, take this" label (default).
+- ``bug`` — a bug-fixer style workflow that fires when an issue is triaged as a
+  bug (mirrors the upstream ``bug-fixer`` example).
+
+Authorisation
+-------------
+
+Authorise on the **issue author's** association
+(``contains(fromJSON('["OWNER", "MEMBER"]'), github.event.issue.author_association)``),
+matching the OWNER/MEMBER convention used by the mention-dispatch templates. Only
+repo writers can apply labels, but the author guard additionally avoids acting on
+issues opened by outside accounts that happen to receive the label. Do **not** use
+the upstream example's hard-coded username allowlist — it does not generalise.
+
+Do **not** add ``@jules-*`` handle guards; those belong only to mention-dispatch.
+
+Prompt structure
+----------------
+
+Issue context comes from ``github.event.issue.*`` (there is no triggering comment).
+Otherwise follow the standard ordering in ``SKILL.md``: role + project overview,
+orientation process, role-specific reference material, the injected issue context,
+then the instructions block.
+
+For a bug-fixer style label, the instructions block typically asks Jules to:
+analyse the report and identify the root cause, trace the issue through the
+codebase, implement a minimal targeted fix, add a regression test that would have
+caught the bug, and "open a pull request when complete."
+
+Injection prevention
+--------------------
+
+The template reads the issue title and body via ``gh issue view`` and writes them
+to ``$GITHUB_OUTPUT`` using a randomised heredoc delimiter
+(``DELIM=$(openssl rand -hex 8)``), exactly as the mention-dispatch templates do.
+Never use a fixed delimiter.

--- a/skills/jules-dispatch-creator/references/label-dispatch.rst
+++ b/skills/jules-dispatch-creator/references/label-dispatch.rst
@@ -37,8 +37,12 @@ The worst case is wasted API quota / an unsolicited PR (no secret exposure, no
 privilege escalation), but if your threat model cares, add a labeler check on
 ``github.event.sender.login`` against a CODEOWNERS/allowlist, or restrict label
 application via repository settings. A ``concurrency`` group keyed on the issue
-number (``jules-label-${{ github.event.issue.number }}``) also dedupes rapid
-label toggling on the same issue.
+number (``jules-label-${{ github.event.issue.number }}``) serialises repeated
+labelling of the same issue. It uses ``cancel-in-progress: false`` so a re-label
+queues behind an in-flight dispatch rather than cancelling it: the Jules
+invocation is dispatched asynchronously, so cancelling the workflow mid-run would
+not stop Jules — it would only suppress the confirmation comment and leave the
+session running unannounced.
 
 Do **not** add ``@jules-*`` handle guards; those belong only to mention-dispatch.
 

--- a/skills/jules-dispatch-creator/references/label-dispatch.rst
+++ b/skills/jules-dispatch-creator/references/label-dispatch.rst
@@ -24,10 +24,21 @@ Authorisation
 
 Authorise on the **issue author's** association
 (``contains(fromJSON('["OWNER", "MEMBER"]'), github.event.issue.author_association)``),
-matching the OWNER/MEMBER convention used by the mention-dispatch templates. Only
-repo writers can apply labels, but the author guard additionally avoids acting on
-issues opened by outside accounts that happen to receive the label. Do **not** use
-the upstream example's hard-coded username allowlist — it does not generalise.
+matching the OWNER/MEMBER convention used by the mention-dispatch templates. Do
+**not** use the upstream example's hard-coded username allowlist — it does not
+generalise.
+
+This gates on the issue **author**, not on whoever applied the label — GitHub's
+``labeled`` event does not expose the labeler's association in a comparable field.
+Be aware of the limitation: the **Triage** role can apply labels *without* write
+access, so on a repo that grants Triage to outside collaborators, a Triage actor
+could apply the trigger label to an OWNER/MEMBER-authored issue and start Jules.
+The worst case is wasted API quota / an unsolicited PR (no secret exposure, no
+privilege escalation), but if your threat model cares, add a labeler check on
+``github.event.sender.login`` against a CODEOWNERS/allowlist, or restrict label
+application via repository settings. A ``concurrency`` group keyed on the issue
+number (``jules-label-${{ github.event.issue.number }}``) also dedupes rapid
+label toggling on the same issue.
 
 Do **not** add ``@jules-*`` handle guards; those belong only to mention-dispatch.
 

--- a/skills/jules-dispatch-creator/references/mention-dispatch.rst
+++ b/skills/jules-dispatch-creator/references/mention-dispatch.rst
@@ -1,0 +1,172 @@
+Mention-dispatch workflows
+==========================
+
+Mention-dispatch workflows fire on ``issue_comment`` when a maintainer mentions a
+``@jules-<handle>`` in a comment on an issue. They are for **human-initiated,
+free-form** work: a person decides Jules should act on a specific issue and says
+so. Templates: ``jules-{swe,security,docs,infra}-dispatch.yml.tmpl``.
+
+Read this file when generating any mention-dispatch role. It carries the per-role
+prompt guidance, the canonical handle set, and the guard rule that keeps the
+templates from double-firing.
+
+General roles
+-------------
+
+The skill ships templates for four general starter personas. Match the density of
+each prompt's instruction block to what the role actually needs (see
+"Instruction density" in ``SKILL.md``).
+
+SWE
+~~~
+
+Keep the prompt thin. If a comprehensive ``CLAUDE.md`` exists, reference it
+explicitly — Jules will read it — and do **not** reproduce its contents, which
+creates a second source of truth that diverges from the real one.
+
+Orientation notes must point to documents, not encode facts. If Phase 1 reveals a
+non-obvious layout (e.g. Python under ``backend/`` rather than the repo root),
+resist encoding that fact in the prompt. Point Jules to the stable document that
+describes it — ``docs/ARCHITECTURE.md`` or wherever the layout lives. A prompt
+that says "all Python source lives under ``backend/``" becomes wrong the moment a
+PR moves things and the docs are updated; "read ``docs/ARCHITECTURE.md`` for the
+current project layout" stays accurate indefinitely, and Jules benefits from every
+docs improvement. This applies to any structural fact that can change: entry
+points, module names, directory conventions. If the structural documentation is
+missing or stale, file a GitHub issue — do not correct it in the system prompt.
+
+::
+
+   You are a Software Engineer working on [project name] — [one-sentence description].
+
+   Read `CLAUDE.md` at the repo root for the authoritative project layout, commands,
+   testing strategy, and conventions before starting work. Read `docs/ARCHITECTURE.md`
+   for the current system topology and entry points.
+
+   [Add only what neither CLAUDE.md nor ARCHITECTURE.md covers.]
+
+   ## GitHub Issue ...
+   ## Triggering comment
+   ## Instructions
+   Implement the request described in the issue. Open a pull request when complete.
+
+If no ``CLAUDE.md`` exists, include enough pattern-based context to navigate
+(architecture style, key directories, test runner) — but prefer conventions over
+exhaustive file lists, which go stale.
+
+Security
+~~~~~~~~
+
+Describe risk *patterns* tied to this stack, not specific files. The issue tells
+Jules where to focus; the system prompt should help Jules recognise *what kind of
+threats* to look for. Specific file paths become incorrect as the code evolves.
+
+Point Jules to ``docs/ARCHITECTURE.md`` (and ``CLAUDE.md`` if present) for
+orientation — encode the *process* of reading stable documents, not the structural
+facts those documents contain. Pattern-based guidance looks like:
+
+- "This stack generates SQL from config files — SQL injection from config values
+  is a risk class to assess."
+- "User-controlled strings are used to construct filesystem paths — path traversal
+  is a risk class."
+- "Credentials are passed through environment variables — check for leakage into
+  logs or error responses."
+
+Keep the severity model and PR conventions stable. The instructions block should
+specify: what to produce (findings as PR comments or a report file), the severity
+classification expected (e.g. critical / high / medium / low), whether to fix or
+only report, and "Open a pull request with your findings when complete."
+
+Docs
+~~~~
+
+Reference the three structural doc files if present (discovered in Phase 1) — they
+are stable anchors, not ephemeral ``docs/`` subpaths:
+
+- ``ARCHITECTURE.md`` — system topology, infra, languages, setup
+- ``DESIGN.md`` — component layout, design decisions
+- ``CONTRIBUTING.md`` — contribution patterns; often LLM-specific conventions
+
+Do **not** list ad-hoc files under ``docs/``; those paths change frequently and
+listing them leads Jules to edit the wrong files or create duplicates. Instead
+describe the process: read source code first and treat existing docs as
+potentially outdated until verified; verify every claim against code before
+writing; follow the project's writing standards (tone, tense, heading style,
+``docs:`` commit prefix). The instructions block should name the files in scope
+(the structural files above plus ``README.md``; avoid open-ended lists), the
+commit prefix, and end with "Open a pull request when complete."
+
+Infra
+~~~~~
+
+Infrastructure changes carry real operational risk. Give Jules a hard boundary: it
+writes and validates IaC in the repository, but has **no access to live
+infrastructure** — no CLI calls, no API calls, no applying changes.
+
+Include: stable architecture context (tools, platforms, layout; reference
+``ARCHITECTURE.md`` if present); per-tool conventions (naming, module structure,
+coding standards for each IaC tool — Ansible, Terraform, Helm; reference
+``CONTRIBUTING.md`` if it covers these); and explicit constraints —
+
+- No live infra access — no ``terraform apply``, no ``ansible-playbook``, no
+  ``kubectl apply``.
+- Validation is repo-local only: ``terraform validate``, ``ansible-lint``,
+  ``helm lint``, etc.
+
+Expect Jules to follow existing patterns before introducing new abstractions and
+to validate all changes before committing. The instructions block ends with "Open
+a pull request with the implementation when complete."
+
+Project-specific personas (example)
+------------------------------------
+
+Some repos add personas beyond the four general roles. For example,
+``nq-rdl/agent-skills`` deploys ``@jules-review`` (an issue reviewer) and
+``@jules-skills`` (a skill engineer) whose prompts are hardwired to that project.
+The skill does **not** ship general templates for these — their prompts are too
+project-specific to generalise — but the canonical handle set below includes them
+because every deployed ``issue_comment`` workflow must guard against every handle
+present in the target repo. When a project wants such a persona, copy a general
+mention-dispatch template, write the project-specific prompt, and add the new
+handle to the canonical set in that repo.
+
+Canonical handle set & guard rule
+----------------------------------
+
+Every mention-dispatch workflow guards against **all other** ``@jules-*`` handles,
+so that a comment naming two handles dispatches only the intended one. The
+canonical handle set is the single source of truth for which guards each template
+carries.
+
+For ``nq-rdl/agent-skills`` the canonical set is:
+
+- ``swe``, ``security``, ``docs``, ``infra`` — general roles
+- ``review``, ``skills`` — project-specific personas
+
+The rule: **every** ``issue_comment`` **template must trigger on its own handle
+(**``contains(github.event.comment.body, '@jules-<own>')``**) and guard
+(**``!contains(...)``**) against every other handle in the canonical set.**
+``author_association`` must be ``OWNER`` or ``MEMBER`` only — never
+``COLLABORATOR``.
+
+Adding a handle therefore means updating the ``!contains`` guard in *every*
+existing ``issue_comment`` template — the templates in ``templates/`` are the
+canonical source, so update them and regenerate any deployed workflows. This
+invariant is enforced automatically by
+``tests/skills/test_jules_dispatch_creator_templates.py`` (the ``MENTION_HANDLES``
+tuple is the single source of truth there); keep that tuple in sync with this list.
+
+**Exception —** ``ci-workflow-run``**:** that family uses ``workflow_run`` and does
+**not** use ``!contains`` guards. Never add a ``@jules-*`` guard to it. The same
+applies to the other non-``issue_comment`` families (``label-dispatch``,
+``scheduled``, ``issue-lifecycle``).
+
+Injection prevention
+--------------------
+
+Every mention-dispatch template uses a randomised heredoc delimiter
+(``DELIM=$(openssl rand -hex 8)``) when writing the issue ``title`` and ``body`` to
+``$GITHUB_OUTPUT``. This prevents a crafted issue title or body that contains a
+fixed delimiter string on its own line from breaking out of the heredoc and
+injecting arbitrary output. Never use a fixed string like ``ISSUE_EOF`` as a
+heredoc delimiter.

--- a/skills/jules-dispatch-creator/references/scheduled.rst
+++ b/skills/jules-dispatch-creator/references/scheduled.rst
@@ -17,7 +17,10 @@ e.g. ``0 2 * * 1`` (Mondays 02:00 UTC) for a weekly cleanup or ``0 4 * * *`` for
 daily performance pass.
 
 A ``concurrency`` group prevents overlapping runs from racing each other (a slow
-maintenance run should not collide with the next scheduled tick).
+maintenance run should not collide with the next scheduled tick). It uses
+``cancel-in-progress: false`` so a manual ``workflow_dispatch`` or the next cron
+tick queues behind an in-flight pass rather than killing a long-running
+maintenance session.
 
 No authorisation guard
 ----------------------

--- a/skills/jules-dispatch-creator/references/scheduled.rst
+++ b/skills/jules-dispatch-creator/references/scheduled.rst
@@ -1,0 +1,51 @@
+Scheduled workflows
+===================
+
+Scheduled workflows fire on a ``schedule`` (cron) and on ``workflow_dispatch``
+(manual run). They are for **repo-controlled, recurring maintenance** with no human
+actor and no issue context — codebase cleanup, performance sweeps, dependency
+hygiene. Template: ``jules-scheduled.yml.tmpl``.
+
+Read this file when generating a scheduled workflow.
+
+Trigger and concurrency
+-----------------------
+
+The trigger is ``schedule`` with ``- cron: "[CRON_SCHEDULE]"`` plus a bare
+``workflow_dispatch:`` for manual runs. Choose ``[CRON_SCHEDULE]`` for the cadence,
+e.g. ``0 2 * * 1`` (Mondays 02:00 UTC) for a weekly cleanup or ``0 4 * * *`` for a
+daily performance pass.
+
+A ``concurrency`` group prevents overlapping runs from racing each other (a slow
+maintenance run should not collide with the next scheduled tick).
+
+No authorisation guard
+----------------------
+
+There is **no triggering actor** and **no issue context**, so this family uses
+**no** ``author_association`` check and **no** ``@jules-*`` handle guards — only
+repo writers can edit the cron or click "Run workflow". Adding such guards would be
+meaningless here.
+
+Prompt contents
+---------------
+
+Scheduled prompts describe **stable focus areas and an orientation process**, not a
+snapshot of the codebase (snapshots go stale; process does not). Typical focus
+areas for a cleanup pass:
+
+- dead-code removal (unused symbols, commented-out blocks, unreachable paths)
+- duplication (refactor into reusable functions; apply DRY)
+- complexity reduction (simplify and decompose large functions; reduce nesting)
+- naming improvements and formatting/import organisation
+
+For a performance pass, describe the categories to scan (e.g. re-renders and code
+splitting on the frontend, N+1 queries and caching on the backend, algorithms and
+data structures generally).
+
+**Critical guardrail.** Because the workflow runs unattended, instruct Jules to
+open a pull request **only** when it has a validated, impactful change — make
+incremental, safe refactorings, preserve existing functionality, run tests to
+verify, and "do not open a PR without a validated and impactful change." This
+mirrors the upstream ``weekly-cleanup`` and ``performance-improver`` guidance and
+prevents a stream of low-value automated PRs.

--- a/skills/jules-dispatch-creator/templates/jules-issue-lifecycle.yml.tmpl
+++ b/skills/jules-dispatch-creator/templates/jules-issue-lifecycle.yml.tmpl
@@ -45,22 +45,37 @@ jobs:
           script: |
             const closed = context.payload.issue.number;
             const { owner, repo } = context.repo;
-            // Adjust this pattern to match your dependency-tracking convention.
-            const blockedBy = /(?:blocked by|depends on)\s+#(\d+)/gi;
+            // Adjust this pattern to match your dependency-tracking convention. It
+            // captures every "#N" inside a "blocked by …" / "depends on …" clause,
+            // including comma/"and"-separated lists like "blocked by #1, #2 and #3".
+            const blockedBy = /(?:blocked by|depends on)\s+((?:#\d+[\s,]*(?:and\s+)?)+)/gi;
 
             const open = await github.paginate(github.rest.issues.listForRepo, {
               owner, repo, state: "open", per_page: 100,
             });
 
+            // Cache blocker states so each blocker issue is fetched at most once per
+            // run — repos with shared blockers would otherwise issue redundant REST
+            // calls. The just-closed issue is closed by definition (this is the
+            // `issues: [closed]` event), so seed it to skip a guaranteed lookup.
+            const stateCache = new Map([[closed, "closed"]]);
+            const blockerState = async (number) => {
+              if (!stateCache.has(number)) {
+                const { data } = await github.rest.issues.get({ owner, repo, issue_number: number });
+                stateCache.set(number, data.state);
+              }
+              return stateCache.get(number);
+            };
+
             const ready = [];
             for (const issue of open) {
               if (issue.pull_request) continue;
-              const blockers = [...(issue.body || "").matchAll(blockedBy)].map((m) => Number(m[1]));
+              const blockers = [...(issue.body || "").matchAll(blockedBy)]
+                .flatMap((m) => [...m[1].matchAll(/#(\d+)/g)].map((r) => Number(r[1])));
               if (!blockers.includes(closed)) continue;
               let allClosed = true;
               for (const b of blockers) {
-                const { data: dep } = await github.rest.issues.get({ owner, repo, issue_number: b });
-                if (dep.state !== "closed") { allClosed = false; break; }
+                if ((await blockerState(b)) !== "closed") { allClosed = false; break; }
               }
               if (allClosed) ready.push(issue.number);
             }

--- a/skills/jules-dispatch-creator/templates/jules-issue-lifecycle.yml.tmpl
+++ b/skills/jules-dispatch-creator/templates/jules-issue-lifecycle.yml.tmpl
@@ -1,0 +1,99 @@
+# Template: Jules issue-lifecycle (unblocked-issues) workflow.
+#
+# Trigger: `issues: [closed]`. A first job finds open issues that were blocked by
+# the just-closed issue ("blocked by #N" / "depends on #N" syntax) and are now
+# fully unblocked; a second job fans out over those issue numbers and invokes
+# Jules on each. This is NOT issue_comment and does NOT use @jules-* handle guards.
+#
+# Detection is implemented inline with actions/github-script rather than a
+# third-party action, so there is no unverifiable external dependency to pin and
+# the "blocked by" convention is explicit and adjustable below.
+#
+# Placeholders to replace before deploying:
+#   [SECRET_NAME]     — GitHub Actions secret name for the Jules API key
+#   [PROMPT CONTENT]  — repo-specific prompt (indented 12 spaces)
+#
+# Authorisation: each unblocked issue's author association must be OWNER or
+# MEMBER before Jules is invoked on it. author_association comes from the REST
+# API (gh issue view does not expose it), and github-script's core.setOutput is
+# injection-safe, so no bash heredoc is needed here.
+name: Jules Issue Lifecycle
+
+on:
+  issues:
+    types: [closed]
+
+jobs:
+  detect-unblocked:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+    outputs:
+      matrix: ${{ steps.finder.outputs.issues }}
+      found: ${{ steps.finder.outputs.has_issues }}
+    steps:
+      - name: Find issues unblocked by the closed issue
+        id: finder
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const closed = context.payload.issue.number;
+            const { owner, repo } = context.repo;
+            // Adjust this pattern to match your dependency-tracking convention.
+            const blockedBy = /(?:blocked by|depends on)\s+#(\d+)/gi;
+
+            const open = await github.paginate(github.rest.issues.listForRepo, {
+              owner, repo, state: "open", per_page: 100,
+            });
+
+            const ready = [];
+            for (const issue of open) {
+              if (issue.pull_request) continue;
+              const blockers = [...(issue.body || "").matchAll(blockedBy)].map((m) => Number(m[1]));
+              if (!blockers.includes(closed)) continue;
+              let allClosed = true;
+              for (const b of blockers) {
+                const { data: dep } = await github.rest.issues.get({ owner, repo, issue_number: b });
+                if (dep.state !== "closed") { allClosed = false; break; }
+              }
+              if (allClosed) ready.push(issue.number);
+            }
+            core.setOutput("issues", JSON.stringify(ready));
+            core.setOutput("has_issues", (ready.length > 0).toString());
+
+  implement:
+    needs: detect-unblocked
+    if: needs.detect-unblocked.outputs.found == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: read
+    strategy:
+      matrix:
+        issue-number: ${{ fromJSON(needs.detect-unblocked.outputs.matrix) }}
+    steps:
+      - name: Fetch issue details
+        id: issue
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: issue } = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: ${{ matrix.issue-number }},
+            });
+            const allowed = ["OWNER", "MEMBER"];
+            core.setOutput("authorized", allowed.includes(issue.author_association).toString());
+            core.setOutput("title", issue.title);
+            core.setOutput("body", issue.body || "No description provided.");
+
+      - name: Invoke Jules on unblocked issue
+        if: steps.issue.outputs.authorized == 'true'
+        uses: nq-rdl/jules-action@d8ed19ed75a6c2a35fd4e06e5b2ca7cd68b27046  # pinned 2026-04-02
+        with:
+          jules_api_key: ${{ secrets.[SECRET_NAME] }}
+          include_commit_log: true
+          require_plan_approval: false
+          title: "Unblocked #${{ matrix.issue-number }}: ${{ steps.issue.outputs.title }}"
+          prompt: |
+            [PROMPT CONTENT]

--- a/skills/jules-dispatch-creator/templates/jules-issue-lifecycle.yml.tmpl
+++ b/skills/jules-dispatch-creator/templates/jules-issue-lifecycle.yml.tmpl
@@ -23,6 +23,12 @@ on:
   issues:
     types: [closed]
 
+# Serialise the pipeline per closed issue so a rapid close/reopen/close does not
+# launch overlapping detection sweeps.
+concurrency:
+  group: jules-issue-lifecycle-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
 jobs:
   detect-unblocked:
     runs-on: ubuntu-latest
@@ -69,6 +75,9 @@ jobs:
       contents: read
       issues: read
     strategy:
+      # Each unblocked issue is independent work — a failed dispatch on one must
+      # not cancel the dispatches for the others.
+      fail-fast: false
       matrix:
         issue-number: ${{ fromJSON(needs.detect-unblocked.outputs.matrix) }}
     steps:
@@ -95,5 +104,7 @@ jobs:
           include_commit_log: true
           require_plan_approval: false
           title: "Unblocked #${{ matrix.issue-number }}: ${{ steps.issue.outputs.title }}"
+          # The unblocked issue's title and body are available to the prompt as
+          # ${{ steps.issue.outputs.title }} and ${{ steps.issue.outputs.body }}.
           prompt: |
             [PROMPT CONTENT]

--- a/skills/jules-dispatch-creator/templates/jules-label-dispatch.yml.tmpl
+++ b/skills/jules-dispatch-creator/templates/jules-label-dispatch.yml.tmpl
@@ -9,8 +9,11 @@
 #   [TRIGGER_LABEL]   — issue label that triggers Jules, e.g. "jules" or "bug"
 #
 # Authorisation: the issue author's association must be OWNER or MEMBER, matching
-# the issue_comment templates. Only repo writers can apply labels, but the author
-# guard avoids acting on issues opened by outside accounts that get the label.
+# the issue_comment templates. This gates on the issue AUTHOR — the `labeled`
+# event does not expose the labeler's association. Note that GitHub's Triage role
+# can apply labels without write access, so on repos that grant Triage to outside
+# collaborators the label is a weaker signal; add a labeler/CODEOWNERS check if
+# your threat model needs it. See references/label-dispatch.rst.
 name: Jules Label Dispatch
 
 on:
@@ -20,6 +23,9 @@ on:
 jobs:
   dispatch:
     runs-on: ubuntu-latest
+    concurrency:
+      group: jules-label-${{ github.event.issue.number }}
+      cancel-in-progress: true
     if: >
       github.event.label.name == '[TRIGGER_LABEL]' &&
       contains(fromJSON('["OWNER", "MEMBER"]'), github.event.issue.author_association)

--- a/skills/jules-dispatch-creator/templates/jules-label-dispatch.yml.tmpl
+++ b/skills/jules-dispatch-creator/templates/jules-label-dispatch.yml.tmpl
@@ -25,7 +25,11 @@ jobs:
     runs-on: ubuntu-latest
     concurrency:
       group: jules-label-${{ github.event.issue.number }}
-      cancel-in-progress: true
+      # Queue rather than cancel: the Invoke Jules step dispatches a long-running
+      # async session, so cancelling a re-labelled run mid-flight would leave Jules
+      # working with no confirmation comment. issue-lifecycle uses false for the
+      # same reason.
+      cancel-in-progress: false
     if: >
       github.event.label.name == '[TRIGGER_LABEL]' &&
       contains(fromJSON('["OWNER", "MEMBER"]'), github.event.issue.author_association)
@@ -86,4 +90,4 @@ jobs:
         run: |
           gh issue comment "$ISSUE_NUMBER" \
             --repo "$REPO" \
-            --body "🚀 Jules dispatched from the \`${{ github.event.label.name }}\` label."
+            --body "🚀 Jules dispatched from the \`[TRIGGER_LABEL]\` label."

--- a/skills/jules-dispatch-creator/templates/jules-label-dispatch.yml.tmpl
+++ b/skills/jules-dispatch-creator/templates/jules-label-dispatch.yml.tmpl
@@ -1,0 +1,83 @@
+# Template: Jules label-triggered dispatch workflow.
+#
+# Trigger: `issues: [labeled]` — fires when a chosen label is applied to an
+# issue. This is NOT issue_comment and does NOT use @jules-* handle guards.
+#
+# Placeholders to replace before deploying:
+#   [SECRET_NAME]     — GitHub Actions secret name for the Jules API key
+#   [PROMPT CONTENT]  — repo-specific prompt (indented 12 spaces)
+#   [TRIGGER_LABEL]   — issue label that triggers Jules, e.g. "jules" or "bug"
+#
+# Authorisation: the issue author's association must be OWNER or MEMBER, matching
+# the issue_comment templates. Only repo writers can apply labels, but the author
+# guard avoids acting on issues opened by outside accounts that get the label.
+name: Jules Label Dispatch
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.label.name == '[TRIGGER_LABEL]' &&
+      contains(fromJSON('["OWNER", "MEMBER"]'), github.event.issue.author_association)
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Fetch issue context
+        id: issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh issue view "$ISSUE_NUMBER" \
+            --repo "$REPO" \
+            --json title,body,labels \
+            --jq '{title, body, labels: [.labels[].name]}' > /tmp/issue.json
+
+          ISSUE_TITLE=$(jq -r '.title' /tmp/issue.json)
+          ISSUE_BODY=$(jq -r '.body // "No description provided."' /tmp/issue.json)
+          ISSUE_LABELS=$(jq -r '.labels | join(", ")' /tmp/issue.json)
+
+          # Use random delimiters to prevent injection via crafted issue content
+          DELIM=$(openssl rand -hex 8)
+
+          {
+            echo "title<<$DELIM"
+            echo "$ISSUE_TITLE"
+            echo "$DELIM"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "body<<$DELIM"
+            echo "$ISSUE_BODY"
+            echo "$DELIM"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "labels=$ISSUE_LABELS" >> "$GITHUB_OUTPUT"
+
+      - name: Invoke Jules
+        uses: nq-rdl/jules-action@d8ed19ed75a6c2a35fd4e06e5b2ca7cd68b27046  # pinned 2026-04-02
+        with:
+          jules_api_key: ${{ secrets.[SECRET_NAME] }}
+          include_commit_log: true
+          require_plan_approval: false
+          title: "Label: ${{ steps.issue.outputs.title }}"
+          prompt: |
+            [PROMPT CONTENT]
+
+      - name: Comment to confirm dispatch
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh issue comment "$ISSUE_NUMBER" \
+            --repo "$REPO" \
+            --body "🚀 Jules dispatched from the \`${{ github.event.label.name }}\` label."

--- a/skills/jules-dispatch-creator/templates/jules-scheduled.yml.tmpl
+++ b/skills/jules-dispatch-creator/templates/jules-scheduled.yml.tmpl
@@ -1,0 +1,36 @@
+# Template: Jules scheduled maintenance workflow.
+#
+# Trigger: `schedule` (cron) plus `workflow_dispatch` for manual runs. There is
+# NO issue context and NO triggering actor, so this template uses NO @jules-*
+# handle guards and NO author_association check — only repo writers can edit the
+# cron or click "Run workflow". A concurrency group prevents overlapping runs.
+#
+# Placeholders to replace before deploying:
+#   [SECRET_NAME]     — GitHub Actions secret name for the Jules API key
+#   [PROMPT CONTENT]  — repo-specific prompt (indented 12 spaces)
+#   [CRON_SCHEDULE]   — cron expression, e.g. "0 2 * * 1" (Mondays 02:00 UTC)
+name: Jules Scheduled Maintenance
+
+on:
+  schedule:
+    - cron: "[CRON_SCHEDULE]"
+  workflow_dispatch:
+
+jobs:
+  maintenance:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: jules-scheduled-${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    permissions:
+      contents: read
+    steps:
+      - name: Invoke Jules — Scheduled Maintenance
+        uses: nq-rdl/jules-action@d8ed19ed75a6c2a35fd4e06e5b2ca7cd68b27046  # pinned 2026-04-02
+        with:
+          jules_api_key: ${{ secrets.[SECRET_NAME] }}
+          include_commit_log: true
+          require_plan_approval: false
+          title: "Scheduled maintenance: ${{ github.workflow }}"
+          prompt: |
+            [PROMPT CONTENT]

--- a/skills/jules-dispatch-creator/templates/jules-scheduled.yml.tmpl
+++ b/skills/jules-dispatch-creator/templates/jules-scheduled.yml.tmpl
@@ -21,7 +21,10 @@ jobs:
     runs-on: ubuntu-latest
     concurrency:
       group: jules-scheduled-${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
+      # Queue rather than cancel: a maintenance pass can run for a long time, so a
+      # manual workflow_dispatch or the next cron tick should wait behind an
+      # in-flight run instead of killing it.
+      cancel-in-progress: false
     permissions:
       contents: read
     steps:

--- a/tests/skills/test_jules_dispatch_creator_templates.py
+++ b/tests/skills/test_jules_dispatch_creator_templates.py
@@ -33,6 +33,16 @@ MENTION_TEMPLATES = {
     "jules-infra-dispatch.yml.tmpl": "infra",
 }
 
+# Templates whose triggers can fire repeatedly/automatically and so need a
+# concurrency group to avoid overlapping or duplicate Jules sessions. Mention
+# templates are excluded: a human types one mention at a time.
+CONCURRENCY_TEMPLATES = (
+    "jules-scheduled.yml.tmpl",
+    "jules-ci-review-dispatch.yml.tmpl",
+    "jules-label-dispatch.yml.tmpl",
+    "jules-issue-lifecycle.yml.tmpl",
+)
+
 # Every template the skill ships, mapped to the trigger key expected in its
 # `on:` block (which parses to the boolean key True). For `issues` triggers the
 # value also names the event type that must appear under `types:`.
@@ -108,6 +118,23 @@ def test_mention_guard_completeness(name):
         assert f"!contains(github.event.comment.body, '@jules-{other}')" in text, (
             f"{name}: must guard against @jules-{other}"
         )
+
+
+@pytest.mark.parametrize("name", CONCURRENCY_TEMPLATES)
+def test_repeatable_templates_have_concurrency(name):
+    assert "concurrency:" in _read(name), (
+        f"{name}: a repeatable/automatic trigger needs a concurrency group to "
+        f"avoid overlapping Jules sessions"
+    )
+
+
+def test_issue_lifecycle_matrix_is_fail_safe():
+    # Unblocked issues are independent work — one failing dispatch must not
+    # cancel the others, so the matrix must opt out of fail-fast.
+    text = _read("jules-issue-lifecycle.yml.tmpl")
+    assert "fail-fast: false" in text, (
+        "jules-issue-lifecycle.yml.tmpl: matrix over independent issues must set fail-fast: false"
+    )
 
 
 @pytest.mark.parametrize("name", sorted(EXPECTED_TRIGGERS))

--- a/tests/skills/test_jules_dispatch_creator_templates.py
+++ b/tests/skills/test_jules_dispatch_creator_templates.py
@@ -1,0 +1,126 @@
+"""Structural tests for the jules-dispatch-creator workflow templates.
+
+The templates are GitHub Actions workflow YAML containing [PLACEHOLDER] tokens
+that the skill fills in at generation time. The tokens sit in string/scalar
+positions, so the templates parse as valid YAML as-is.
+
+YAML 1.1 gotcha: GitHub Actions' `on:` key parses to the boolean key ``True``
+(``yaml.safe_load`` returns keys ``['name', True, 'jobs']``), so trigger lookups
+use that key, not the string ``"on"``.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+TEMPLATES_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "skills"
+    / "jules-dispatch-creator"
+    / "templates"
+)
+
+# Canonical @jules-* handle set for issue_comment (mention-dispatch) workflows.
+# Adding a handle here makes the guard-completeness test enforce it everywhere.
+MENTION_HANDLES = ("swe", "security", "docs", "infra", "review", "skills")
+
+# Mention-dispatch templates mapped to the handle each one triggers on.
+MENTION_TEMPLATES = {
+    "jules-swe-dispatch.yml.tmpl": "swe",
+    "jules-security-dispatch.yml.tmpl": "security",
+    "jules-docs-dispatch.yml.tmpl": "docs",
+    "jules-infra-dispatch.yml.tmpl": "infra",
+}
+
+# Every template the skill ships, mapped to the trigger key expected in its
+# `on:` block (which parses to the boolean key True). For `issues` triggers the
+# value also names the event type that must appear under `types:`.
+EXPECTED_TRIGGERS = {
+    "jules-swe-dispatch.yml.tmpl": ("issue_comment", None),
+    "jules-security-dispatch.yml.tmpl": ("issue_comment", None),
+    "jules-docs-dispatch.yml.tmpl": ("issue_comment", None),
+    "jules-infra-dispatch.yml.tmpl": ("issue_comment", None),
+    "jules-ci-review-dispatch.yml.tmpl": ("workflow_run", None),
+    "jules-label-dispatch.yml.tmpl": ("issues", "labeled"),
+    "jules-scheduled.yml.tmpl": ("schedule", None),
+    "jules-issue-lifecycle.yml.tmpl": ("issues", "closed"),
+}
+
+PINNED_JULES_ACTION = re.compile(r"nq-rdl/jules-action@[0-9a-f]{40}")
+
+
+def _read(name: str) -> str:
+    return (TEMPLATES_DIR / name).read_text(encoding="utf-8")
+
+
+def _on_block(doc: dict):
+    # `on:` becomes the boolean key True under YAML 1.1.
+    return doc.get(True, doc.get("on"))
+
+
+@pytest.mark.parametrize("name", sorted(EXPECTED_TRIGGERS))
+def test_template_file_exists(name):
+    assert (TEMPLATES_DIR / name).is_file(), f"missing template: {name}"
+
+
+@pytest.mark.parametrize("name", sorted(EXPECTED_TRIGGERS))
+def test_template_parses_as_yaml(name):
+    doc = yaml.safe_load(_read(name))
+    assert isinstance(doc, dict)
+    assert "jobs" in doc
+    assert _on_block(doc) is not None
+
+
+@pytest.mark.parametrize("name", sorted(EXPECTED_TRIGGERS))
+def test_template_declares_expected_trigger(name):
+    trigger, event_type = EXPECTED_TRIGGERS[name]
+    on = _on_block(yaml.safe_load(_read(name)))
+    assert trigger in on, f"{name}: expected trigger {trigger!r} in {sorted(on)}"
+    if event_type is not None:
+        types = on[trigger].get("types", [])
+        assert event_type in types, f"{name}: expected {event_type!r} in types {types}"
+    if name == "jules-scheduled.yml.tmpl":
+        assert "workflow_dispatch" in on, f"{name}: scheduled must allow manual runs"
+
+
+@pytest.mark.parametrize("name", sorted(EXPECTED_TRIGGERS))
+def test_template_uses_nq_rdl_conventions(name):
+    text = _read(name)
+    assert PINNED_JULES_ACTION.search(text), f"{name}: missing pinned nq-rdl/jules-action"
+    assert "secrets.[SECRET_NAME]" in text, f"{name}: missing [SECRET_NAME] placeholder"
+    assert "[PROMPT CONTENT]" in text, f"{name}: missing [PROMPT CONTENT] placeholder"
+    # Must not copy the upstream example's invocation or secret name.
+    assert "google-labs-code/jules-invoke" not in text
+    assert "secrets.JULES_API_KEY" not in text
+
+
+@pytest.mark.parametrize("name", sorted(MENTION_TEMPLATES))
+def test_mention_guard_completeness(name):
+    text = _read(name)
+    own = MENTION_TEMPLATES[name]
+    assert f"contains(github.event.comment.body, '@jules-{own}')" in text, (
+        f"{name}: must trigger on its own handle @jules-{own}"
+    )
+    for other in MENTION_HANDLES:
+        if other == own:
+            continue
+        assert f"!contains(github.event.comment.body, '@jules-{other}')" in text, (
+            f"{name}: must guard against @jules-{other}"
+        )
+
+
+@pytest.mark.parametrize("name", sorted(EXPECTED_TRIGGERS))
+def test_no_fixed_heredoc_delimiter(name):
+    # SKILL.md rule: never use a fixed heredoc delimiter for issue content.
+    text = _read(name)
+    for bad in ("<<EOF", "<<'EOF'", "ISSUE_EOF"):
+        assert bad not in text, f"{name}: fixed heredoc delimiter {bad!r} is injection-prone"
+    # Any bash heredoc writing to GITHUB_OUTPUT must use a random delimiter.
+    if '"$GITHUB_OUTPUT"' in text and "<<" in text:
+        assert "openssl rand -hex 8" in text, (
+            f"{name}: bash heredoc to GITHUB_OUTPUT must use a random delimiter"
+        )

--- a/tests/skills/test_jules_dispatch_creator_templates.py
+++ b/tests/skills/test_jules_dispatch_creator_templates.py
@@ -59,6 +59,19 @@ EXPECTED_TRIGGERS = {
 
 PINNED_JULES_ACTION = re.compile(r"nq-rdl/jules-action@[0-9a-f]{40}")
 
+# Template-specific placeholders the skill fills at generation time. If one is
+# accidentally hardcoded to a concrete value, the file stops being a template;
+# these assertions lock the tokens in place.
+TEMPLATE_SPECIFIC_PLACEHOLDERS = {
+    "jules-label-dispatch.yml.tmpl": ("[TRIGGER_LABEL]",),
+    "jules-scheduled.yml.tmpl": ("[CRON_SCHEDULE]",),
+    "jules-ci-review-dispatch.yml.tmpl": ("[CI_WORKFLOW_NAMES]",),
+}
+
+# Opener of a multiline GITHUB_OUTPUT write, e.g. `echo "body<<$DELIM"`. The
+# captured group is the heredoc delimiter, which must be the random $DELIM.
+GITHUB_OUTPUT_HEREDOC = re.compile(r'echo\s+"[A-Za-z_]+<<(\S+?)"')
+
 
 def _read(name: str) -> str:
     return (TEMPLATES_DIR / name).read_text(encoding="utf-8")
@@ -137,14 +150,31 @@ def test_issue_lifecycle_matrix_is_fail_safe():
     )
 
 
+@pytest.mark.parametrize("name", sorted(TEMPLATE_SPECIFIC_PLACEHOLDERS))
+def test_template_specific_placeholders_present(name):
+    # A hardcoded value where a [PLACEHOLDER] belongs silently breaks generation.
+    text = _read(name)
+    for placeholder in TEMPLATE_SPECIFIC_PLACEHOLDERS[name]:
+        assert placeholder in text, f"{name}: missing template-specific placeholder {placeholder}"
+
+
 @pytest.mark.parametrize("name", sorted(EXPECTED_TRIGGERS))
 def test_no_fixed_heredoc_delimiter(name):
-    # SKILL.md rule: never use a fixed heredoc delimiter for issue content.
+    # SKILL.md rule: never use a fixed heredoc delimiter for issue content — a
+    # crafted title/body could otherwise close the block early and inject output.
     text = _read(name)
     for bad in ("<<EOF", "<<'EOF'", "ISSUE_EOF"):
         assert bad not in text, f"{name}: fixed heredoc delimiter {bad!r} is injection-prone"
-    # Any bash heredoc writing to GITHUB_OUTPUT must use a random delimiter.
-    if '"$GITHUB_OUTPUT"' in text and "<<" in text:
+    # Validate every multiline GITHUB_OUTPUT write individually: each delimiter
+    # must be the random $DELIM, not a fixed string. Checking each marker (rather
+    # than "openssl appears somewhere in the file") catches a single unprotected
+    # field even when its siblings are protected.
+    markers = GITHUB_OUTPUT_HEREDOC.findall(text)
+    for marker in markers:
+        assert marker == "$DELIM", (
+            f"{name}: GITHUB_OUTPUT heredoc delimiter {marker!r} must be the random $DELIM"
+        )
+    if markers:
         assert "openssl rand -hex 8" in text, (
-            f"{name}: bash heredoc to GITHUB_OUTPUT must use a random delimiter"
+            f"{name}: $DELIM must be generated with `openssl rand -hex 8`"
         )

--- a/tests/skills/test_jules_dispatch_creator_templates.py
+++ b/tests/skills/test_jules_dispatch_creator_templates.py
@@ -18,10 +18,7 @@ import pytest
 import yaml
 
 TEMPLATES_DIR = (
-    Path(__file__).resolve().parents[2]
-    / "skills"
-    / "jules-dispatch-creator"
-    / "templates"
+    Path(__file__).resolve().parents[2] / "skills" / "jules-dispatch-creator" / "templates"
 )
 
 # Canonical @jules-* handle set for issue_comment (mention-dispatch) workflows.


### PR DESCRIPTION
Closes nq-rdl/agent-extensions#132.

Expands `jules-dispatch-creator` from a role-centric model (4 mention roles + ci-review) to a **trigger-family** model covering every pattern in the [jules-action examples README](https://github.com/google-labs-code/jules-action/blob/main/examples/README.md), with per-family `.rst` references for progressive disclosure.

## Trigger families

| Family | Trigger | Status |
|---|---|---|
| `mention-dispatch` | `issue_comment` + `@jules-<handle>` | refactored into `references/mention-dispatch.rst` |
| `label-dispatch` | `issues: [labeled]` | **new** template + ref |
| `scheduled` | `schedule` + `workflow_dispatch` | **new** template + ref |
| `ci-workflow-run` | `workflow_run` (failure) | refactored into `references/ci-workflow-run.rst` |
| `issue-lifecycle` | `issues: [closed]` | **new** template + ref |

## What changed

- **3 new templates** — `jules-label-dispatch`, `jules-scheduled`, `jules-issue-lifecycle`. All follow the established nq-rdl conventions (pinned `nq-rdl/jules-action@<sha>`, `secrets.[SECRET_NAME]`, `author_association` OWNER/MEMBER where there's an actor, randomized-heredoc injection guards, concurrency on repeatable triggers).
- **SKILL.md slimmed 383 → 216 lines** — now an orchestrator with a trigger-family selection table; per-family detail lives in 5 new `references/*.rst` files.
- **Handle drift reconciled** — the mention templates already guarded all 6 handles (`swe/security/docs/infra/review/skills`); only the prose was stale. `mention-dispatch.rst` now documents the canonical set, frames `review`/`skills` as project-specific persona examples, and states the guard rule as a principle. A new test enforces guard-completeness so the drift can't recur.
- **Catalog + registry** — added the (previously missing) `jules-dispatch-creator` row to `docs/skills.md` and the skills registry.
- **Tests (TDD)** — new `tests/skills/test_jules_dispatch_creator_templates.py` (49 cases): YAML validity (handling the GHA `on:`→`True` YAML-1.1 gotcha), per-trigger assertions, nq-rdl invocation conventions, the guard-completeness invariant, concurrency on repeatable triggers, fail-safe matrix, and injection-safe heredocs. Declares `pyyaml` as an explicit test dependency.

## Notes for reviewers

- **Phantom upstream actions:** the upstream `unblocked-issues` example references `google-labs-code/on-unblocked@v1` and `google-labs-code/jules-invoke@v1` — **neither exists** as a real repo (verified via API). The `issue-lifecycle` template therefore implements unblock-detection inline with `actions/github-script@v7` (real, pinnable, already used by ci-review), parallel to how the skill already adapts the phantom `jules-invoke` → the real pinned `nq-rdl/jules-action`.
- This PR was developed brainstorm → spec → plan → TDD → adversarial multi-agent audit. The audit confirmed 8 medium/low findings (no critical/high); all were addressed (fail-fast, concurrency, the Triage-label authz limitation, doc-accuracy fixes). Spec/plan live under `docs/superpowers/`.
- Validation: `format`, `lint`, `typecheck`, `test` (94), `validate-skills` (43) all green.

> Generated with Claude Code.